### PR TITLE
Cleanup/small fixes

### DIFF
--- a/src/main/java/org/b612foundation/adam/datamodel/PropagationParameters.java
+++ b/src/main/java/org/b612foundation/adam/datamodel/PropagationParameters.java
@@ -2,6 +2,10 @@ package org.b612foundation.adam.datamodel;
 
 import java.util.Objects;
 
+import org.b612foundation.adam.opm.OdmFormatter;
+import org.b612foundation.adam.opm.OdmParseException;
+import org.b612foundation.adam.opm.OrbitParameterMessage;
+
 public class PropagationParameters {
 
   /** Beginning of the ephemerides. Should be UTC. Generated ephemerides will start at this time. */
@@ -12,8 +16,18 @@ public class PropagationParameters {
   private long step_duration_sec;
   /** Settings for the numeric propagator - the ID. */
   private String propagator_uuid;
-  /** OPM as a single string in CCSDS format */
-  private String opm_string;
+  /** OPM as parsed from a single string in CCSDS format */
+  private OrbitParameterMessage opm;
+  
+  public PropagationParameters deepCopy() {
+    PropagationParameters copy = new PropagationParameters();
+    copy.setEnd_time(end_time);
+    copy.setOpm(opm.deepCopy());
+    copy.setPropagator_uuid(propagator_uuid);
+    copy.setStart_time(start_time);
+    copy.setStep_duration_sec(step_duration_sec);
+    return copy;
+  }
 
   public String getStart_time() {
     return start_time;
@@ -50,19 +64,23 @@ public class PropagationParameters {
     this.propagator_uuid = propagator_uuid;
     return this;
   }
-
-  public String getOpm_string() {
-    return opm_string;
+  
+  public OrbitParameterMessage getOpm() {
+    return opm;
   }
-
-  public PropagationParameters setOpm_string(String opm_string) {
-    this.opm_string = opm_string;
+  
+  public PropagationParameters setOpm(OrbitParameterMessage opm) {
+    this.opm = opm;
     return this;
+  }
+  
+  public void setOpmFromString(String opmString) throws OdmParseException {
+    this.opm = OdmFormatter.parseOpmString(opmString);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(end_time, opm_string, propagator_uuid, start_time, step_duration_sec);
+    return Objects.hash(end_time, opm, propagator_uuid, start_time, step_duration_sec);
   }
 
   @Override
@@ -74,7 +92,7 @@ public class PropagationParameters {
     if (getClass() != obj.getClass())
       return false;
     PropagationParameters other = (PropagationParameters) obj;
-    return Objects.equals(end_time, other.end_time) && Objects.equals(opm_string, other.opm_string)
+    return Objects.equals(end_time, other.end_time) && Objects.equals(opm, other.opm)
         && Objects.equals(propagator_uuid, other.propagator_uuid) && Objects.equals(start_time, other.start_time)
         && Objects.equals(step_duration_sec, other.step_duration_sec);
   }

--- a/src/main/java/org/b612foundation/adam/opm/AdamField.java
+++ b/src/main/java/org/b612foundation/adam/opm/AdamField.java
@@ -1,6 +1,7 @@
 package org.b612foundation.adam.opm;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 public class AdamField implements Serializable {
   private String key, value;
@@ -28,11 +29,7 @@ public class AdamField implements Serializable {
 
   @Override
   public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((key == null) ? 0 : key.hashCode());
-    result = prime * result + ((value == null) ? 0 : value.hashCode());
-    return result;
+    return Objects.hash(key, value);
   }
 
   @Override
@@ -44,17 +41,7 @@ public class AdamField implements Serializable {
     if (getClass() != obj.getClass())
       return false;
     AdamField other = (AdamField) obj;
-    if (key == null) {
-      if (other.key != null)
-        return false;
-    } else if (!key.equals(other.key))
-      return false;
-    if (value == null) {
-      if (other.value != null)
-        return false;
-    } else if (!value.equals(other.value))
-      return false;
-    return true;
+    return Objects.equals(key, other.key) && Objects.equals(value, other.value);
   }
 
   @Override

--- a/src/main/java/org/b612foundation/adam/opm/CovarianceMatrix.java
+++ b/src/main/java/org/b612foundation/adam/opm/CovarianceMatrix.java
@@ -3,6 +3,7 @@ package org.b612foundation.adam.opm;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Position/Velocity Covariance Matrix (6x6 Lower Triangular Form. None or all parameters of the matrix must be given.
@@ -18,12 +19,51 @@ public class CovarianceMatrix implements Serializable {
   /**
    * Covariance matrix. The variables are in order x,y,z,x',y',z'. Units are km and km/s, with corresponding products.
    */
-  private double cXX;
+  private double CXX;
   private double CYX, CYY;
   private double CZX, CZY, CZZ;
   private double CXdotX, CXdotY, CXdotZ, CXdotXdot;
   private double CYdotX, CYdotY, CYdotZ, CYdotXdot, CYdotYdot;
   private double CZdotX, CZdotY, CZdotZ, CZdotXdot, CZdotYdot, CZdotZdot;
+  
+  public CovarianceMatrix deepCopy() {
+    CovarianceMatrix copy = new CovarianceMatrix();
+    for (String comment : comments) {
+      copy.addComment(comment);
+    }
+    
+    copy.setEpoch(epoch);
+    copy.setCov_ref_frame(covRefFrame);
+    
+    copy.setCx_x(CXX);
+    
+    copy.setCy_x(CYX);
+    copy.setCy_y(CYY);
+
+    copy.setCz_x(CZX);
+    copy.setCz_y(CZY);
+    copy.setCz_z(CZZ);
+
+    copy.setCx_dot_x(CXdotX);
+    copy.setCx_dot_y(CXdotY);
+    copy.setCx_dot_z(CXdotZ);
+    copy.setCx_dot_x_dot(CXdotXdot);
+
+    copy.setCy_dot_x(CYdotX);
+    copy.setCy_dot_y(CYdotY);
+    copy.setCy_dot_z(CYdotZ);
+    copy.setCy_dot_x_dot(CYdotXdot);
+    copy.setCy_dot_y_dot(CYdotYdot);
+
+    copy.setCz_dot_x(CZdotX);
+    copy.setCz_dot_y(CZdotY);
+    copy.setCz_dot_z(CZdotZ);
+    copy.setCz_dot_x_dot(CZdotXdot);
+    copy.setCz_dot_y_dot(CZdotYdot);
+    copy.setCz_dot_z_dot(CZdotZdot);
+    
+    return copy;
+  }
 
   public List<String> getComments() {
     return comments;
@@ -58,11 +98,11 @@ public class CovarianceMatrix implements Serializable {
   }
 
   public double getCx_x() {
-    return cXX;
+    return CXX;
   }
 
   public CovarianceMatrix setCx_x(double cXX) {
-    this.cXX = cXX;
+    this.CXX = cXX;
     return this;
   }
 
@@ -248,55 +288,16 @@ public class CovarianceMatrix implements Serializable {
 
   @Override
   public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    long temp;
-    temp = Double.doubleToLongBits(CXdotX);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(CXdotXdot);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(CXdotY);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(CXdotZ);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(CYX);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(CYY);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(CYdotX);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(CYdotXdot);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(CYdotY);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(CYdotYdot);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(CYdotZ);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(CZX);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(CZY);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(CZZ);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(CZdotX);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(CZdotXdot);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(CZdotY);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(CZdotYdot);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(CZdotZ);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(CZdotZdot);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(cXX);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    result = prime * result + ((comments == null) ? 0 : comments.hashCode());
-    result = prime * result + ((covRefFrame == null) ? 0 : covRefFrame.hashCode());
-    result = prime * result + ((epoch == null) ? 0 : epoch.hashCode());
-    return result;
+    // @formatter:off
+    return Objects.hash(
+        comments, covRefFrame, epoch,
+        CXX,
+        CYX, CYY,
+        CZX, CZY, CZZ,
+        CXdotX, CXdotY, CXdotZ, CXdotXdot,
+        CYdotX, CYdotY, CYdotZ, CYdotXdot, CYdotYdot,
+        CZdotX, CZdotY, CZdotZ, CZdotXdot, CZdotYdot, CZdotZdot);
+    // @formatter:on
   }
 
   @Override
@@ -308,68 +309,29 @@ public class CovarianceMatrix implements Serializable {
     if (getClass() != obj.getClass())
       return false;
     CovarianceMatrix other = (CovarianceMatrix) obj;
-    if (Double.doubleToLongBits(CXdotX) != Double.doubleToLongBits(other.CXdotX))
-      return false;
-    if (Double.doubleToLongBits(CXdotXdot) != Double.doubleToLongBits(other.CXdotXdot))
-      return false;
-    if (Double.doubleToLongBits(CXdotY) != Double.doubleToLongBits(other.CXdotY))
-      return false;
-    if (Double.doubleToLongBits(CXdotZ) != Double.doubleToLongBits(other.CXdotZ))
-      return false;
-    if (Double.doubleToLongBits(CYX) != Double.doubleToLongBits(other.CYX))
-      return false;
-    if (Double.doubleToLongBits(CYY) != Double.doubleToLongBits(other.CYY))
-      return false;
-    if (Double.doubleToLongBits(CYdotX) != Double.doubleToLongBits(other.CYdotX))
-      return false;
-    if (Double.doubleToLongBits(CYdotXdot) != Double.doubleToLongBits(other.CYdotXdot))
-      return false;
-    if (Double.doubleToLongBits(CYdotY) != Double.doubleToLongBits(other.CYdotY))
-      return false;
-    if (Double.doubleToLongBits(CYdotYdot) != Double.doubleToLongBits(other.CYdotYdot))
-      return false;
-    if (Double.doubleToLongBits(CYdotZ) != Double.doubleToLongBits(other.CYdotZ))
-      return false;
-    if (Double.doubleToLongBits(CZX) != Double.doubleToLongBits(other.CZX))
-      return false;
-    if (Double.doubleToLongBits(CZY) != Double.doubleToLongBits(other.CZY))
-      return false;
-    if (Double.doubleToLongBits(CZZ) != Double.doubleToLongBits(other.CZZ))
-      return false;
-    if (Double.doubleToLongBits(CZdotX) != Double.doubleToLongBits(other.CZdotX))
-      return false;
-    if (Double.doubleToLongBits(CZdotXdot) != Double.doubleToLongBits(other.CZdotXdot))
-      return false;
-    if (Double.doubleToLongBits(CZdotY) != Double.doubleToLongBits(other.CZdotY))
-      return false;
-    if (Double.doubleToLongBits(CZdotYdot) != Double.doubleToLongBits(other.CZdotYdot))
-      return false;
-    if (Double.doubleToLongBits(CZdotZ) != Double.doubleToLongBits(other.CZdotZ))
-      return false;
-    if (Double.doubleToLongBits(CZdotZdot) != Double.doubleToLongBits(other.CZdotZdot))
-      return false;
-    if (Double.doubleToLongBits(cXX) != Double.doubleToLongBits(other.cXX))
-      return false;
-    if (comments == null) {
-      if (other.comments != null)
-        return false;
-    } else if (!comments.equals(other.comments))
-      return false;
-    if (covRefFrame != other.covRefFrame)
-      return false;
-    if (epoch == null) {
-      if (other.epoch != null)
-        return false;
-    } else if (!epoch.equals(other.epoch))
-      return false;
-    return true;
+    // @formatter:off
+    return Objects.equals(comments, other.comments)
+        && Objects.equals(covRefFrame, other.covRefFrame)
+        && Objects.equals(epoch, other.epoch)
+        && Objects.equals(CXX, other.CXX)
+        && Objects.equals(CYX, other.CYX) && Objects.equals(CYY, other.CYY)
+        && Objects.equals(CZX, other.CZX) && Objects.equals(CZY, other.CZY) && Objects.equals(CZZ, other.CZZ)
+        && Objects.equals(CXdotX, other.CXdotX) && Objects.equals(CXdotY, other.CXdotY)
+          && Objects.equals(CXdotZ, other.CXdotZ) && Objects.equals(CXdotXdot, other.CXdotXdot)
+        && Objects.equals(CYdotX, other.CYdotX) && Objects.equals(CYdotY, other.CYdotY)
+          && Objects.equals(CYdotZ, other.CYdotZ) && Objects.equals(CYdotXdot, other.CYdotXdot)
+          && Objects.equals(CYdotYdot, other.CYdotYdot)
+        && Objects.equals(CZdotX, other.CZdotX) && Objects.equals(CZdotY, other.CZdotY)
+          && Objects.equals(CZdotZ, other.CZdotZ) && Objects.equals(CZdotXdot, other.CZdotXdot)
+          && Objects.equals(CZdotYdot, other.CZdotYdot) && Objects.equals(CZdotZdot, other.CZdotZdot);
+    // @formatter:on
   }
 
   @Override
   public String toString() {
     StringBuilder builder = new StringBuilder();
     builder.append("CovarianceMatrix [comments=").append(comments).append(", epoch=").append(epoch)
-        .append(", covRefFrame=").append(covRefFrame).append(", cXX=").append(cXX).append(", CYX=").append(CYX)
+        .append(", covRefFrame=").append(covRefFrame).append(", cXX=").append(CXX).append(", CYX=").append(CYX)
         .append(", CYY=").append(CYY).append(", CZX=").append(CZX).append(", CZY=").append(CZY).append(", CZZ=")
         .append(CZZ).append(", CXdotX=").append(CXdotX).append(", CXdotY=").append(CXdotY).append(", CXdotZ=")
         .append(CXdotZ).append(", CXdotXdot=").append(CXdotXdot).append(", CYdotX=").append(CYdotX).append(", CYdotY=")

--- a/src/main/java/org/b612foundation/adam/opm/KeplerianElements.java
+++ b/src/main/java/org/b612foundation/adam/opm/KeplerianElements.java
@@ -3,6 +3,7 @@ package org.b612foundation.adam.opm;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Osculating Keplerian Elements in the specified reference frame (none or all parameters of this block must be given.)
@@ -39,7 +40,7 @@ public class KeplerianElements implements Serializable {
   public KeplerianElements deepCopy() {
     KeplerianElements res = new KeplerianElements();
     for (String c : comments)
-      res.addComment(new String(c));
+      res.addComment(c);
     res.setSemi_major_axis(semiMajorAxis);
     res.setMean_motion(meanMotion);
     res.setEccentricity(eccentricity);
@@ -149,29 +150,8 @@ public class KeplerianElements implements Serializable {
 
   @Override
   public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    long temp;
-    temp = Double.doubleToLongBits(argOfPericenter);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    result = prime * result + ((comments == null) ? 0 : comments.hashCode());
-    temp = Double.doubleToLongBits(eccentricity);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(gm);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(inclination);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(meanAnomaly);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(meanMotion);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(raOfAscNode);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(semiMajorAxis);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(trueAnomaly);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    return result;
+    return Objects.hash(argOfPericenter, comments, eccentricity, gm, inclination, meanAnomaly, meanMotion, raOfAscNode,
+        semiMajorAxis, trueAnomaly);
   }
 
   @Override
@@ -183,30 +163,18 @@ public class KeplerianElements implements Serializable {
     if (getClass() != obj.getClass())
       return false;
     KeplerianElements other = (KeplerianElements) obj;
-    if (Double.doubleToLongBits(argOfPericenter) != Double.doubleToLongBits(other.argOfPericenter))
-      return false;
-    if (comments == null) {
-      if (other.comments != null)
-        return false;
-    } else if (!comments.equals(other.comments))
-      return false;
-    if (Double.doubleToLongBits(eccentricity) != Double.doubleToLongBits(other.eccentricity))
-      return false;
-    if (Double.doubleToLongBits(gm) != Double.doubleToLongBits(other.gm))
-      return false;
-    if (Double.doubleToLongBits(inclination) != Double.doubleToLongBits(other.inclination))
-      return false;
-    if (Double.doubleToLongBits(meanAnomaly) != Double.doubleToLongBits(other.meanAnomaly))
-      return false;
-    if (Double.doubleToLongBits(meanMotion) != Double.doubleToLongBits(other.meanMotion))
-      return false;
-    if (Double.doubleToLongBits(raOfAscNode) != Double.doubleToLongBits(other.raOfAscNode))
-      return false;
-    if (Double.doubleToLongBits(semiMajorAxis) != Double.doubleToLongBits(other.semiMajorAxis))
-      return false;
-    if (Double.doubleToLongBits(trueAnomaly) != Double.doubleToLongBits(other.trueAnomaly))
-      return false;
-    return true;
+    // @formatter:off
+    return Objects.equals(argOfPericenter, other.argOfPericenter)
+        && Objects.equals(comments, other.comments)
+        && Objects.equals(eccentricity, other.eccentricity)
+        && Objects.equals(gm, other.gm)
+        && Objects.equals(inclination, other.inclination)
+        && Objects.equals(meanAnomaly, other.meanAnomaly)
+        && Objects.equals(meanMotion, other.meanMotion)
+        && Objects.equals(raOfAscNode, other.raOfAscNode)
+        && Objects.equals(semiMajorAxis, other.semiMajorAxis)
+        && Objects.equals(trueAnomaly, other.trueAnomaly);
+    // @formatter:on
   }
 
   @Override

--- a/src/main/java/org/b612foundation/adam/opm/Manuever.java
+++ b/src/main/java/org/b612foundation/adam/opm/Manuever.java
@@ -3,6 +3,7 @@ package org.b612foundation.adam.opm;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Description of an individual manuever (burn). Used in OPM. https://public.ccsds.org/Pubs/502x0b2c1.pdf
@@ -24,9 +25,8 @@ public class Manuever implements Serializable {
   public Manuever deepCopy() {
     Manuever res = new Manuever();
     for (String c : comments)
-      res.addComment(new String(c));
-    if (manEpochIgnition != null)
-      res.setMan_epoch_ignition(new String(manEpochIgnition));
+      res.addComment(c);
+    res.setMan_epoch_ignition(manEpochIgnition);
     res.setDuration(duration);
     res.setDelta_mass(deltaMass);
     res.setMan_ref_frame(manRefFrame);
@@ -115,23 +115,7 @@ public class Manuever implements Serializable {
 
   @Override
   public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((comments == null) ? 0 : comments.hashCode());
-    long temp;
-    temp = Double.doubleToLongBits(deltaMass);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(duration);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(manDv1);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(manDv2);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(manDv3);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    result = prime * result + ((manEpochIgnition == null) ? 0 : manEpochIgnition.hashCode());
-    result = prime * result + ((manRefFrame == null) ? 0 : manRefFrame.hashCode());
-    return result;
+    return Objects.hash(comments, deltaMass, duration, manDv1, manDv2, manDv3, manEpochIgnition, manRefFrame);
   }
 
   @Override
@@ -143,29 +127,16 @@ public class Manuever implements Serializable {
     if (getClass() != obj.getClass())
       return false;
     Manuever other = (Manuever) obj;
-    if (comments == null) {
-      if (other.comments != null)
-        return false;
-    } else if (!comments.equals(other.comments))
-      return false;
-    if (Double.doubleToLongBits(deltaMass) != Double.doubleToLongBits(other.deltaMass))
-      return false;
-    if (Double.doubleToLongBits(duration) != Double.doubleToLongBits(other.duration))
-      return false;
-    if (Double.doubleToLongBits(manDv1) != Double.doubleToLongBits(other.manDv1))
-      return false;
-    if (Double.doubleToLongBits(manDv2) != Double.doubleToLongBits(other.manDv2))
-      return false;
-    if (Double.doubleToLongBits(manDv3) != Double.doubleToLongBits(other.manDv3))
-      return false;
-    if (manEpochIgnition == null) {
-      if (other.manEpochIgnition != null)
-        return false;
-    } else if (!manEpochIgnition.equals(other.manEpochIgnition))
-      return false;
-    if (manRefFrame != other.manRefFrame)
-      return false;
-    return true;
+    // @formatter:off
+    return Objects.equals(comments, other.comments)
+        && Objects.equals(deltaMass, other.deltaMass)
+        && Objects.equals(duration, other.duration)
+        && Objects.equals(manDv1, other.manDv1)
+        && Objects.equals(manDv2, other.manDv2)
+        && Objects.equals(manDv3, other.manDv3)
+        && Objects.equals(manEpochIgnition, other.manEpochIgnition)
+        && Objects.equals(manRefFrame, other.manRefFrame);
+    // @formatter:on
   }
 
   @Override

--- a/src/main/java/org/b612foundation/adam/opm/OdmCommonHeader.java
+++ b/src/main/java/org/b612foundation/adam/opm/OdmCommonHeader.java
@@ -3,6 +3,7 @@ package org.b612foundation.adam.opm;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Header fields are common for all three ODM messages. https://public.ccsds.org/Pubs/502x0b2c1.pdf
@@ -20,11 +21,9 @@ public class OdmCommonHeader implements Serializable {
   public OdmCommonHeader deepCopy() {
     OdmCommonHeader res = new OdmCommonHeader();
     for (String c : comments)
-      res.addComment(new String(c));
-    if (creationDate != null)
-      res.setCreation_date(new String(creationDate));
-    if (originator != null)
-      res.setOriginator(new String(originator));
+      res.addComment(c);
+    res.setCreation_date(creationDate);
+    res.setOriginator(originator);
     return res;
   }
 
@@ -57,12 +56,7 @@ public class OdmCommonHeader implements Serializable {
 
   @Override
   public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((comments == null) ? 0 : comments.hashCode());
-    result = prime * result + ((creationDate == null) ? 0 : creationDate.hashCode());
-    result = prime * result + ((originator == null) ? 0 : originator.hashCode());
-    return result;
+    return Objects.hash(comments, creationDate, originator);
   }
 
   @Override
@@ -74,22 +68,8 @@ public class OdmCommonHeader implements Serializable {
     if (getClass() != obj.getClass())
       return false;
     OdmCommonHeader other = (OdmCommonHeader) obj;
-    if (comments == null) {
-      if (other.comments != null)
-        return false;
-    } else if (!comments.equals(other.comments))
-      return false;
-    if (creationDate == null) {
-      if (other.creationDate != null)
-        return false;
-    } else if (!creationDate.equals(other.creationDate))
-      return false;
-    if (originator == null) {
-      if (other.originator != null)
-        return false;
-    } else if (!originator.equals(other.originator))
-      return false;
-    return true;
+    return Objects.equals(comments, other.comments) && Objects.equals(creationDate, other.creationDate)
+        && Objects.equals(originator, other.originator);
   }
 
   @Override

--- a/src/main/java/org/b612foundation/adam/opm/OdmCommonMetadata.java
+++ b/src/main/java/org/b612foundation/adam/opm/OdmCommonMetadata.java
@@ -3,6 +3,7 @@ package org.b612foundation.adam.opm;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Metadata fields common to all three ODM messages. https://public.ccsds.org/Pubs/502x0b2c1.pdf
@@ -112,15 +113,12 @@ public class OdmCommonMetadata implements Serializable {
   public OdmCommonMetadata deepCopy() {
     OdmCommonMetadata res = new OdmCommonMetadata();
     for (String c : comments)
-      res.addComment(new String(c));
-    if (objectName != null)
-      res.setObject_name(new String(objectName));
-    if (objectId != null)
-      res.setObject_id(new String(objectId));
+      res.addComment(c);
+    res.setObject_name(objectName);
+    res.setObject_id(objectId);
     res.setCenter_name(centerName);
     res.setRef_frame(refFrame);
-    if (refFrameEpoch != null)
-      res.setRef_frame_epoch(new String(refFrameEpoch));
+    res.setRef_frame_epoch(refFrameEpoch);
     res.setTime_system(timeSystem);
     return res;
   }
@@ -195,16 +193,7 @@ public class OdmCommonMetadata implements Serializable {
 
   @Override
   public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((centerName == null) ? 0 : centerName.hashCode());
-    result = prime * result + ((comments == null) ? 0 : comments.hashCode());
-    result = prime * result + ((objectId == null) ? 0 : objectId.hashCode());
-    result = prime * result + ((objectName == null) ? 0 : objectName.hashCode());
-    result = prime * result + ((refFrame == null) ? 0 : refFrame.hashCode());
-    result = prime * result + ((refFrameEpoch == null) ? 0 : refFrameEpoch.hashCode());
-    result = prime * result + ((timeSystem == null) ? 0 : timeSystem.hashCode());
-    return result;
+    return Objects.hash(centerName, comments, objectId, objectName, refFrame, refFrameEpoch, timeSystem);
   }
 
   @Override
@@ -216,33 +205,15 @@ public class OdmCommonMetadata implements Serializable {
     if (getClass() != obj.getClass())
       return false;
     OdmCommonMetadata other = (OdmCommonMetadata) obj;
-    if (centerName != other.centerName)
-      return false;
-    if (comments == null) {
-      if (other.comments != null)
-        return false;
-    } else if (!comments.equals(other.comments))
-      return false;
-    if (objectId == null) {
-      if (other.objectId != null)
-        return false;
-    } else if (!objectId.equals(other.objectId))
-      return false;
-    if (objectName == null) {
-      if (other.objectName != null)
-        return false;
-    } else if (!objectName.equals(other.objectName))
-      return false;
-    if (refFrame != other.refFrame)
-      return false;
-    if (refFrameEpoch == null) {
-      if (other.refFrameEpoch != null)
-        return false;
-    } else if (!refFrameEpoch.equals(other.refFrameEpoch))
-      return false;
-    if (timeSystem != other.timeSystem)
-      return false;
-    return true;
+    // @formatter:off
+    return Objects.equals(centerName, other.centerName)
+        && Objects.equals(comments, other.comments)
+        && Objects.equals(objectId, other.objectId)
+        && Objects.equals(objectName, other.objectName)
+        && Objects.equals(refFrame, other.refFrame)
+        && Objects.equals(refFrameEpoch, other.refFrameEpoch)
+        && Objects.equals(timeSystem, other.timeSystem);
+    // @formatter:on
   }
 
   @Override

--- a/src/main/java/org/b612foundation/adam/opm/OrbitParameterMessage.java
+++ b/src/main/java/org/b612foundation/adam/opm/OrbitParameterMessage.java
@@ -3,6 +3,7 @@ package org.b612foundation.adam.opm;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Orbit Parameter Message, or OPM, one of the three high-level message types defined in CCSDS ODM standard.
@@ -45,6 +46,10 @@ public class OrbitParameterMessage implements Serializable {
       res.setState_vector(stateVector.deepCopy());
     if (keplerian != null)
       res.setKeplerian(keplerian.deepCopy());
+    if (spacecraft != null)
+      res.setSpacecraft(spacecraft.deepCopy());
+    if (covariance != null)
+      res.setCovariance(covariance.deepCopy());
     for (Manuever man : manuevers)
       res.addManuever(man.deepCopy());
     for (AdamField af : adamFields)
@@ -145,18 +150,8 @@ public class OrbitParameterMessage implements Serializable {
 
   @Override
   public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((adamFields == null) ? 0 : adamFields.hashCode());
-    result = prime * result + ((ccsdsOpmVers == null) ? 0 : ccsdsOpmVers.hashCode());
-    result = prime * result + ((covariance == null) ? 0 : covariance.hashCode());
-    result = prime * result + ((header == null) ? 0 : header.hashCode());
-    result = prime * result + ((keplerian == null) ? 0 : keplerian.hashCode());
-    result = prime * result + ((manuevers == null) ? 0 : manuevers.hashCode());
-    result = prime * result + ((metadata == null) ? 0 : metadata.hashCode());
-    result = prime * result + ((spacecraft == null) ? 0 : spacecraft.hashCode());
-    result = prime * result + ((stateVector == null) ? 0 : stateVector.hashCode());
-    return result;
+    return Objects.hash(adamFields, ccsdsOpmVers, covariance, header, keplerian, manuevers, metadata, spacecraft,
+        stateVector);
   }
 
   @Override
@@ -168,52 +163,17 @@ public class OrbitParameterMessage implements Serializable {
     if (getClass() != obj.getClass())
       return false;
     OrbitParameterMessage other = (OrbitParameterMessage) obj;
-    if (adamFields == null) {
-      if (other.adamFields != null)
-        return false;
-    } else if (!adamFields.equals(other.adamFields))
-      return false;
-    if (ccsdsOpmVers == null) {
-      if (other.ccsdsOpmVers != null)
-        return false;
-    } else if (!ccsdsOpmVers.equals(other.ccsdsOpmVers))
-      return false;
-    if (covariance == null) {
-      if (other.covariance != null)
-        return false;
-    } else if (!covariance.equals(other.covariance))
-      return false;
-    if (header == null) {
-      if (other.header != null)
-        return false;
-    } else if (!header.equals(other.header))
-      return false;
-    if (keplerian == null) {
-      if (other.keplerian != null)
-        return false;
-    } else if (!keplerian.equals(other.keplerian))
-      return false;
-    if (manuevers == null) {
-      if (other.manuevers != null)
-        return false;
-    } else if (!manuevers.equals(other.manuevers))
-      return false;
-    if (metadata == null) {
-      if (other.metadata != null)
-        return false;
-    } else if (!metadata.equals(other.metadata))
-      return false;
-    if (spacecraft == null) {
-      if (other.spacecraft != null)
-        return false;
-    } else if (!spacecraft.equals(other.spacecraft))
-      return false;
-    if (stateVector == null) {
-      if (other.stateVector != null)
-        return false;
-    } else if (!stateVector.equals(other.stateVector))
-      return false;
-    return true;
+    // @formatter:off
+    return Objects.equals(adamFields, other.adamFields) &&
+        Objects.equals(ccsdsOpmVers, other.ccsdsOpmVers) &&
+        Objects.equals(covariance, other.covariance) &&
+        Objects.equals(header, other.header) &&
+        Objects.equals(keplerian, other.keplerian) &&
+        Objects.equals(manuevers, other.manuevers) &&
+        Objects.equals(metadata, other.metadata) &&
+        Objects.equals(spacecraft, other.spacecraft) &&
+        Objects.equals(stateVector, other.stateVector);
+    // @formatter:on
   }
 
   @Override

--- a/src/main/java/org/b612foundation/adam/opm/SpacecraftParameters.java
+++ b/src/main/java/org/b612foundation/adam/opm/SpacecraftParameters.java
@@ -3,6 +3,7 @@ package org.b612foundation.adam.opm;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * Description of a spacecraft. May be included in OPM or OMM. https://public.ccsds.org/Pubs/502x0b2c1.pdf
@@ -20,6 +21,19 @@ public class SpacecraftParameters implements Serializable {
   private double dragArea;
   /** Drag coefficient. */
   private double dragCoeff;
+
+  public SpacecraftParameters deepCopy() {
+    SpacecraftParameters copy = new SpacecraftParameters();
+    for (String comment : comments) {
+      copy.addComment(comment);
+    }
+    copy.setMass(mass);
+    copy.setSolar_rad_area(solarRadArea);
+    copy.setSolar_rad_coeff(solarRadCoeff);
+    copy.setDrag_area(dragArea);
+    copy.setDrag_coeff(dragCoeff);
+    return copy;
+  }
 
   public List<String> getComments() {
     return comments;
@@ -82,21 +96,7 @@ public class SpacecraftParameters implements Serializable {
 
   @Override
   public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((comments == null) ? 0 : comments.hashCode());
-    long temp;
-    temp = Double.doubleToLongBits(dragArea);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(dragCoeff);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(mass);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(solarRadArea);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(solarRadCoeff);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    return result;
+    return Objects.hash(comments, dragArea, dragCoeff, mass, solarRadArea, solarRadCoeff);
   }
 
   @Override
@@ -108,22 +108,14 @@ public class SpacecraftParameters implements Serializable {
     if (getClass() != obj.getClass())
       return false;
     SpacecraftParameters other = (SpacecraftParameters) obj;
-    if (comments == null) {
-      if (other.comments != null)
-        return false;
-    } else if (!comments.equals(other.comments))
-      return false;
-    if (Double.doubleToLongBits(dragArea) != Double.doubleToLongBits(other.dragArea))
-      return false;
-    if (Double.doubleToLongBits(dragCoeff) != Double.doubleToLongBits(other.dragCoeff))
-      return false;
-    if (Double.doubleToLongBits(mass) != Double.doubleToLongBits(other.mass))
-      return false;
-    if (Double.doubleToLongBits(solarRadArea) != Double.doubleToLongBits(other.solarRadArea))
-      return false;
-    if (Double.doubleToLongBits(solarRadCoeff) != Double.doubleToLongBits(other.solarRadCoeff))
-      return false;
-    return true;
+    // @formatter:off
+    return Objects.equals(comments, other.comments)
+        && Objects.equals(dragArea, other.dragArea)
+        && Objects.equals(dragCoeff, other.dragCoeff)
+        && Objects.equals(mass, other.mass)
+        && Objects.equals(solarRadArea, other.solarRadArea)
+        && Objects.equals(solarRadCoeff, other.solarRadCoeff);
+    // @formatter:on
   }
 
   @Override

--- a/src/main/java/org/b612foundation/adam/opm/StateVector.java
+++ b/src/main/java/org/b612foundation/adam/opm/StateVector.java
@@ -3,6 +3,7 @@ package org.b612foundation.adam.opm;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * State Vector Components. The coordinate system is given in the metadata. https://public.ccsds.org/Pubs/502x0b2c1.pdf
@@ -20,9 +21,8 @@ public class StateVector implements Serializable {
   public StateVector deepCopy() {
     StateVector res = new StateVector();
     for (String c : comments)
-      res.addComment(new String(c));
-    if (epoch != null)
-      res.setEpoch(new String(epoch));
+      res.addComment(c);
+    res.setEpoch(epoch);
     res.setX(x);
     res.setY(y);
     res.setZ(z);
@@ -111,24 +111,7 @@ public class StateVector implements Serializable {
 
   @Override
   public int hashCode() {
-    final int prime = 31;
-    int result = 1;
-    result = prime * result + ((comments == null) ? 0 : comments.hashCode());
-    result = prime * result + ((epoch == null) ? 0 : epoch.hashCode());
-    long temp;
-    temp = Double.doubleToLongBits(x);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(xDot);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(y);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(yDot);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(z);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    temp = Double.doubleToLongBits(zDot);
-    result = prime * result + (int) (temp ^ (temp >>> 32));
-    return result;
+    return Objects.hash(comments, epoch, x, y, z, xDot, yDot, zDot);
   }
 
   @Override
@@ -140,29 +123,16 @@ public class StateVector implements Serializable {
     if (getClass() != obj.getClass())
       return false;
     StateVector other = (StateVector) obj;
-    if (comments == null) {
-      if (other.comments != null)
-        return false;
-    } else if (!comments.equals(other.comments))
-      return false;
-    if (epoch == null) {
-      if (other.epoch != null)
-        return false;
-    } else if (!epoch.equals(other.epoch))
-      return false;
-    if (Double.doubleToLongBits(x) != Double.doubleToLongBits(other.x))
-      return false;
-    if (Double.doubleToLongBits(xDot) != Double.doubleToLongBits(other.xDot))
-      return false;
-    if (Double.doubleToLongBits(y) != Double.doubleToLongBits(other.y))
-      return false;
-    if (Double.doubleToLongBits(yDot) != Double.doubleToLongBits(other.yDot))
-      return false;
-    if (Double.doubleToLongBits(z) != Double.doubleToLongBits(other.z))
-      return false;
-    if (Double.doubleToLongBits(zDot) != Double.doubleToLongBits(other.zDot))
-      return false;
-    return true;
+    // @formatter:off
+    return Objects.equals(comments, other.comments) 
+        && Objects.equals(epoch, other.epoch) 
+        && Objects.equals(x, other.x) 
+        && Objects.equals(y, other.y) 
+        && Objects.equals(z, other.z) 
+        && Objects.equals(xDot, other.xDot) 
+        && Objects.equals(yDot, other.yDot) 
+        && Objects.equals(zDot, other.zDot);
+    // @formatter:on
   }
 
   @Override

--- a/src/test/java/org/b612foundation/adam/opm/OrbitParameterMessageTest.java
+++ b/src/test/java/org/b612foundation/adam/opm/OrbitParameterMessageTest.java
@@ -1,0 +1,23 @@
+package org.b612foundation.adam.opm;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class OrbitParameterMessageTest {
+  
+  @Test
+  public void testDeepCopy() {
+    // Includes metadata, header, state vector, spacecraft.
+    OrbitParameterMessage opmSimple = OdmScenarioBuilder.buildSimpleOpm();
+    Assert.assertEquals(opmSimple, opmSimple.deepCopy());
+
+    // Includes metadata, header, state vector, spacecraft, keplerian, and maneuvers.
+    OrbitParameterMessage opmKeplerianAndManeuvers = OdmScenarioBuilder.buildOpmWithKepelerianAndManuevers();
+    Assert.assertEquals(opmKeplerianAndManeuvers, opmKeplerianAndManeuvers.deepCopy());
+    
+    // Includes metadata, header, state vector, spacecraft, covariance, and ADAM fields.
+    OrbitParameterMessage opmWithCovariance = OdmScenarioBuilder.buildOpmWithCovariance("FACES");
+    Assert.assertEquals(opmWithCovariance, opmWithCovariance.deepCopy());
+  }
+  
+}

--- a/src/test/java/org/b612foundation/adam/opm/OrbitParameterMessageTest.java
+++ b/src/test/java/org/b612foundation/adam/opm/OrbitParameterMessageTest.java
@@ -4,7 +4,69 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class OrbitParameterMessageTest {
-  
+
+  @Test
+  public void sanityCheckEqualsAndHashcode() {
+    // Includes metadata, header, state vector, spacecraft.
+    OrbitParameterMessage opmSimple = OdmScenarioBuilder.buildSimpleOpm();
+    Assert.assertEquals(OdmScenarioBuilder.buildSimpleOpm(), opmSimple);
+    Assert.assertEquals(OdmScenarioBuilder.buildSimpleOpm().hashCode(), opmSimple.hashCode());
+    opmSimple.setCcsds_opm_vers("different");
+    Assert.assertNotEquals(OdmScenarioBuilder.buildSimpleOpm(), opmSimple);
+    Assert.assertNotEquals(OdmScenarioBuilder.buildSimpleOpm().hashCode(), opmSimple.hashCode());
+    opmSimple = OdmScenarioBuilder.buildSimpleOpm();
+    opmSimple.addAdam_field("a", "b");
+    Assert.assertNotEquals(OdmScenarioBuilder.buildSimpleOpm(), opmSimple);
+    Assert.assertNotEquals(OdmScenarioBuilder.buildSimpleOpm().hashCode(), opmSimple.hashCode());
+    opmSimple = OdmScenarioBuilder.buildSimpleOpm();
+    opmSimple.getMetadata().addComment("new");
+    Assert.assertNotEquals(OdmScenarioBuilder.buildSimpleOpm(), opmSimple);
+    Assert.assertNotEquals(OdmScenarioBuilder.buildSimpleOpm().hashCode(), opmSimple.hashCode());
+    opmSimple = OdmScenarioBuilder.buildSimpleOpm();
+    opmSimple.getHeader().addComment("new");
+    Assert.assertNotEquals(OdmScenarioBuilder.buildSimpleOpm(), opmSimple);
+    Assert.assertNotEquals(OdmScenarioBuilder.buildSimpleOpm().hashCode(), opmSimple.hashCode());
+    opmSimple = OdmScenarioBuilder.buildSimpleOpm();
+    opmSimple.getSpacecraft().addComment("new");
+    Assert.assertNotEquals(OdmScenarioBuilder.buildSimpleOpm(), opmSimple);
+    Assert.assertNotEquals(OdmScenarioBuilder.buildSimpleOpm().hashCode(), opmSimple.hashCode());
+    opmSimple = OdmScenarioBuilder.buildSimpleOpm();
+    opmSimple.getState_vector().addComment("new");
+    Assert.assertNotEquals(OdmScenarioBuilder.buildSimpleOpm(), opmSimple);
+    Assert.assertNotEquals(OdmScenarioBuilder.buildSimpleOpm().hashCode(), opmSimple.hashCode());
+
+    // Also has keplerian and maneuvers.
+    OrbitParameterMessage opmKeplerianAndManeuvers = OdmScenarioBuilder.buildOpmWithKepelerianAndManuevers();
+    Assert.assertEquals(OdmScenarioBuilder.buildOpmWithKepelerianAndManuevers(), opmKeplerianAndManeuvers);
+    Assert.assertEquals(OdmScenarioBuilder.buildOpmWithKepelerianAndManuevers().hashCode(),
+        opmKeplerianAndManeuvers.hashCode());
+    opmKeplerianAndManeuvers.getKeplerian().addComment("new");
+    Assert.assertNotEquals(OdmScenarioBuilder.buildOpmWithKepelerianAndManuevers(), opmKeplerianAndManeuvers);
+    Assert.assertNotEquals(OdmScenarioBuilder.buildOpmWithKepelerianAndManuevers().hashCode(),
+        opmKeplerianAndManeuvers.hashCode());
+    opmKeplerianAndManeuvers = OdmScenarioBuilder.buildOpmWithKepelerianAndManuevers();
+    opmKeplerianAndManeuvers.getManuevers().get(0).addComment("new");
+    Assert.assertNotEquals(OdmScenarioBuilder.buildOpmWithKepelerianAndManuevers(), opmKeplerianAndManeuvers);
+    Assert.assertNotEquals(OdmScenarioBuilder.buildOpmWithKepelerianAndManuevers().hashCode(),
+        opmKeplerianAndManeuvers.hashCode());
+
+    // Also has covariance and ADAM fields.
+    OrbitParameterMessage opmWithCovariance = OdmScenarioBuilder.buildOpmWithCovariance("FACES");
+    Assert.assertEquals(OdmScenarioBuilder.buildOpmWithCovariance("FACES"), opmWithCovariance);
+    Assert.assertEquals(OdmScenarioBuilder.buildOpmWithCovariance("FACES").hashCode(), opmWithCovariance.hashCode());
+    opmWithCovariance.getCovariance().addComment("new");
+    Assert.assertNotEquals(OdmScenarioBuilder.buildOpmWithCovariance("FACES"), opmWithCovariance);
+    Assert.assertNotEquals(OdmScenarioBuilder.buildOpmWithCovariance("FACES").hashCode(), opmWithCovariance.hashCode());
+    opmWithCovariance = OdmScenarioBuilder.buildOpmWithCovariance("FACES");
+    opmWithCovariance.getAdam_fields().remove(0);
+    Assert.assertNotEquals(OdmScenarioBuilder.buildOpmWithCovariance("FACES"), opmWithCovariance);
+    Assert.assertNotEquals(OdmScenarioBuilder.buildOpmWithCovariance("FACES").hashCode(), opmWithCovariance.hashCode());
+    opmWithCovariance = OdmScenarioBuilder.buildOpmWithCovariance("FACES");
+    opmWithCovariance.getAdam_fields().get(0).setValue("new");
+    Assert.assertNotEquals(OdmScenarioBuilder.buildOpmWithCovariance("FACES"), opmWithCovariance);
+    Assert.assertNotEquals(OdmScenarioBuilder.buildOpmWithCovariance("FACES").hashCode(), opmWithCovariance.hashCode());
+  }
+
   @Test
   public void testDeepCopy() {
     // Includes metadata, header, state vector, spacecraft.
@@ -14,10 +76,10 @@ public class OrbitParameterMessageTest {
     // Includes metadata, header, state vector, spacecraft, keplerian, and maneuvers.
     OrbitParameterMessage opmKeplerianAndManeuvers = OdmScenarioBuilder.buildOpmWithKepelerianAndManuevers();
     Assert.assertEquals(opmKeplerianAndManeuvers, opmKeplerianAndManeuvers.deepCopy());
-    
+
     // Includes metadata, header, state vector, spacecraft, covariance, and ADAM fields.
     OrbitParameterMessage opmWithCovariance = OdmScenarioBuilder.buildOpmWithCovariance("FACES");
     Assert.assertEquals(opmWithCovariance, opmWithCovariance.deepCopy());
   }
-  
+
 }


### PR DESCRIPTION
A few cleanup changes:
- fix deepCopy for OPM. Add test of this (it omitted a couple fields). NOTE: also removed all new String(...) since it wasn't used for all strings copied, and from my internet searching sounds like because strings are immutable in Java you also get a copy through simple assignment (that is, if you do a = "hi"; b = a; a = "bye"; b will still be "hi". I confirmed exactly that in a test that I did not commit).
- clean up hashcode and equals for OPM classes
- add deepCopy for PropagationParams
- keep OPM instead of opm string in PropagationParams