### PR TITLE
delta-v targeting Initial class modification to support addtional mis…

### DIFF
--- a/src/main/java/org/b612foundation/adam/datamodel/TargetingParameters.java
+++ b/src/main/java/org/b612foundation/adam/datamodel/TargetingParameters.java
@@ -6,6 +6,9 @@ public class TargetingParameters {
 
   /** The distance from earth that should be targeted, in km. */
   private double targetDistanceFromEarth;
+  
+  /** The distance from earth that should be targeted, in km, during the first stage of targeting */
+  private double initialTargetDistanceFromEarth;
 
   /** The tolerance on the targeting of the target distance from earth, in km. */
   private double tolerance;
@@ -22,6 +25,15 @@ public class TargetingParameters {
     return this;
   }
 
+  public double getInitialTargetDistanceFromEarth() {
+    return initialTargetDistanceFromEarth;
+  }
+
+  public TargetingParameters setInitialTargetDistanceFromEarth(double initialTargetDistanceFromEarth) {
+    this.initialTargetDistanceFromEarth = initialTargetDistanceFromEarth;
+    return this;
+  }
+  
   public double getTolerance() {
     return tolerance;
   }
@@ -42,7 +54,7 @@ public class TargetingParameters {
 
   @Override
   public int hashCode() {
-    return Objects.hash(targetDistanceFromEarth, tolerance, runNominalOnly);
+    return Objects.hash(targetDistanceFromEarth, initialTargetDistanceFromEarth, tolerance, runNominalOnly);
   }
 
   @Override
@@ -55,6 +67,7 @@ public class TargetingParameters {
       return false;
     TargetingParameters other = (TargetingParameters) obj;
     return Objects.equals(targetDistanceFromEarth, other.targetDistanceFromEarth)
+        && Objects.equals(initialTargetDistanceFromEarth, other.initialTargetDistanceFromEarth)
         && Objects.equals(tolerance, other.tolerance) && Objects.equals(runNominalOnly, other.runNominalOnly);
   }
 

--- a/src/main/java/org/b612foundation/adam/datamodel/TargetingParameters.java
+++ b/src/main/java/org/b612foundation/adam/datamodel/TargetingParameters.java
@@ -8,7 +8,7 @@ public class TargetingParameters {
   private double targetDistanceFromEarth;
   
   /** The distance from earth that should be targeted, in km, during the first stage of targeting */
-  private double initialTargetDistanceFromEarth;
+  private double initialTargetDistanceFromEarth = -1.0;
 
   /** The tolerance on the targeting of the target distance from earth, in km. */
   private double tolerance;


### PR DESCRIPTION
READY: I added the default value.

This contains the initial changes to add a single new parameter to the API for the delta-v targeting module. In addition to the original "target miss distance" there is now an "initial target miss distance".

I tried to keep the names similar to what was there before.

I'd like to be able to test, in the actual targeter code, for the case where the new parameter is not set by the caller. If I could initialize it to -1 it would work well and I could trap it.

I also wanted to make this argument optional for the REST API , but I didn't know how to do that.

Thanks,
John