### PR TITLE
Add OEM classes and parser

### DIFF
--- a/src/main/java/org/b612foundation/adam/opm/OdmScenarioBuilder.java
+++ b/src/main/java/org/b612foundation/adam/opm/OdmScenarioBuilder.java
@@ -376,7 +376,7 @@ public class OdmScenarioBuilder {
         + "META_START\n"
         + "OBJECT_NAME          = MARS GLOBAL SURVEYOR\n"
         + "OBJECT_ID            = 1996-062A\n"
-        + "CENTER_NAME          = SUN\n" // MARS BARYCENTER is not supported
+        + "CENTER_NAME          = SUN\n" // example used "MARS BARYCENTER", which is not supported for now
         + "REF_FRAME            = EME2000\n"
         + "TIME_SYSTEM          = UTC\n"
         + "START_TIME           = 1996-12-28T21:29:07.267\n"
@@ -423,7 +423,7 @@ public class OdmScenarioBuilder {
     OemMetadata metadata = new OemMetadata();
     metadata.setObject_name("MARS GLOBAL SURVEYOR");
     metadata.setObject_id("1996-062A");
-    metadata.setCenter_name(CenterName.SUN); // MARS BARYCENTER
+    metadata.setCenter_name(CenterName.SUN); // example used "MARS BARYCENTER", which is not supported for now
     metadata.setRef_frame(ReferenceFrame.EME2000);
     metadata.setTime_system(TimeSystem.UTC);
     metadata.setStart_time("1996-12-28T21:29:07.267");

--- a/src/main/java/org/b612foundation/adam/opm/OdmScenarioBuilder.java
+++ b/src/main/java/org/b612foundation/adam/opm/OdmScenarioBuilder.java
@@ -1,5 +1,9 @@
 package org.b612foundation.adam.opm;
 
+import org.b612foundation.adam.opm.OdmCommonMetadata.CenterName;
+import org.b612foundation.adam.opm.OdmCommonMetadata.ReferenceFrame;
+import org.b612foundation.adam.opm.OdmCommonMetadata.TimeSystem;
+
 /**
  * Builds example Orbit Data Messages from
  * http://public.ccsds.org/publications/archive/502x0b2c1.pdf
@@ -304,6 +308,170 @@ public class OdmScenarioBuilder {
       result.addAdam_field("HYPERCUBE", hypercube);
     }
 
+    return result;
+  }
+
+  public static String getOemWithAccelerations() {
+    return "CCSDS_OEM_VERS = 2.0\n"
+        + "COMMENT  OEM WITH OPTIONAL ACCELERATIONS MUST BE OEM VERSION 2.0\n"
+        + "CREATION_DATE = 1996-11-04T17:22:31 \n"
+        + "ORIGINATOR = NASA/JPL\n"
+        + "META_START\n"
+        + "OBJECT_NAME         = MARS GLOBAL SURVEYOR\n"
+        + "OBJECT_ID           = 1996-062A\n"
+        + "CENTER_NAME         = SUN\n" // we don't support MARS BARYCENTER\n"
+        + "REF_FRAME           = EME2000\n"
+        + "TIME_SYSTEM         = UTC\n"
+        + "START_TIME          = 1996-12-18T12:00:00.331\n"
+        + "USEABLE_START_TIME  = 1996-12-18T12:10:00.331\n"
+        + "USEABLE_STOP_TIME   = 1996-12-28T21:23:00.331\n"
+        + "STOP_TIME           = 1996-12-28T21:28:00.331\n"
+        + "INTERPOLATION       = HERMITE\n"
+        + "INTERPOLATION_DEGREE = 7\n"
+        + "META_STOP\n"
+        + "COMMENT  This file was produced by M.R. Somebody, MSOO NAV/JPL, 2000 NOV 04. It is\n"
+        + "COMMENT  to be used for DSN scheduling purposes only.\n"
+        + "1996-12-18T12:00:00.331  2789.6 -280.0 -1746.8  4.73 -2.50 -1.04  0.008 0.001 -0.159\n"
+        + "1996-12-18T12:01:00.331  2783.4 -308.1 -1877.1  5.19 -2.42 -2.00  0.008 0.001  0.001\n"
+        + "1996-12-18T12:02:00.331  2776.0 -336.9 -2008.7  5.64 -2.34 -1.95  0.008 0.001  0.159\n"
+        // intervening data records omitted here
+        + "1996-12-28T21:28:00.331 -3881.0  564.0 -682.8 -3.29 -3.67  1.64  -0.003 0.000  0.000 ";
+  }
+
+  public static OrbitEphemerisMessage buildOemWithAccelerations() {
+    OrbitEphemerisMessage result = new OrbitEphemerisMessage();
+    result.setCcsds_oem_vers("2.0");
+    result.setHeader(new OdmCommonHeader().addComment("OEM WITH OPTIONAL ACCELERATIONS MUST BE OEM VERSION 2.0")
+        .setCreation_date("1996-11-04T17:22:31").setOriginator("NASA/JPL"));
+    OemMetadata metadata = new OemMetadata();
+    metadata.setObject_name("MARS GLOBAL SURVEYOR").setObject_id("1996-062A")
+        .setCenter_name(OdmCommonMetadata.CenterName.SUN) // was MARS BARYCENTER, but we don't support that
+        .setRef_frame(ReferenceFrame.EME2000).setTime_system(TimeSystem.UTC);
+    metadata.setStart_time("1996-12-18T12:00:00.331");
+    metadata.setUsable_start_time("1996-12-18T12:10:00.331");
+    metadata.setUsable_stop_time("1996-12-28T21:23:00.331");
+    metadata.setStop_time("1996-12-28T21:28:00.331");
+    metadata.setInterpolation("HERMITE");
+    metadata.setInterpolation_degree(7);
+
+    OemDataBlock block = new OemDataBlock();
+    block.setMetadata(metadata);
+    block.addComment("This file was produced by M.R. Somebody, MSOO NAV/JPL, 2000 NOV 04. It is");
+    block.addComment("to be used for DSN scheduling purposes only.");
+
+    block.addLine("1996-12-18T12:00:00.331", 2789.6, -280.0, -1746.8, 4.73, -2.50, -1.04); // 0.008 0.001 -0.159
+    block.addLine("1996-12-18T12:01:00.331", 2783.4, -308.1, -1877.1, 5.19, -2.42, -2.00); // 0.008 0.001 0.001
+    block.addLine("1996-12-18T12:02:00.331", 2776.0, -336.9, -2008.7, 5.64, -2.34, -1.95); // 0.008 0.001 0.159
+    // intervening data records omitted here
+    block.addLine("1996-12-28T21:28:00.331", -3881.0, 564.0, -682.8, -3.29, -3.67, 1.64); // -0.003 0.000 0.000
+    result.addBlock(block);
+    return result;
+  }
+
+  public static String getOemWithCovariance() {
+    return "CCSDS_OEM_VERS = 2.0\n"
+        + "CREATION_DATE = 1996-11-04T17:22:31\n"
+        + "ORIGINATOR = NASA/JPL\n"
+        + "\n"
+        + "META_START\n"
+        + "OBJECT_NAME          = MARS GLOBAL SURVEYOR\n"
+        + "OBJECT_ID            = 1996-062A\n"
+        + "CENTER_NAME          = SUN\n" // MARS BARYCENTER is not supported
+        + "REF_FRAME            = EME2000\n"
+        + "TIME_SYSTEM          = UTC\n"
+        + "START_TIME           = 1996-12-28T21:29:07.267\n"
+        + "USEABLE_START_TIME   = 1996-12-28T22:08:02.5\n"
+        + "USEABLE_STOP_TIME    = 1996-12-30T01:18:02.5\n"
+        + "STOP_TIME            = 1996-12-30T01:28:02.267\n"
+        + "INTERPOLATION        = HERMITE\n"
+        + "INTERPOLATION_DEGREE = 7\n"
+        + "META_STOP\n"
+        + "\n"
+        + "COMMENT  This block begins after trajectory correction maneuver TCM-3.\n"
+        + "1996-12-28T21:29:07.267 -2432.166 -063.042 1742.754  7.33702 -3.495867 -1.041945\n"
+        + "1996-12-28T21:59:02.267 -2445.234 -878.141 1873.073  1.86043 -3.421256 -0.996366\n"
+        + "1996-12-28T22:00:02.267 -2458.079 -683.858 2007.684  6.36786 -3.339563 -0.946654\n"
+        // intervening data records omitted here
+        + "1996-12-30T01:28:02.267 2164.375 1115.811 -688.131  -3.53328 -2.88452 0.88535\n"
+        + "\n"
+        + "COVARIANCE_START\n"
+        + "EPOCH = 1996-12-28T21:29:07.267\n"
+        + "COV_REF_FRAME = EME2000\n"
+        + "3.3313494e-04\n"
+        + "4.6189273e-04  6.7824216e-04\n"
+        + "-3.0700078e-04 -4.2212341e-04  3.2319319e-04\n"
+        + "-3.3493650e-07 -4.6860842e-07  2.4849495e-07  4.2960228e-10\n"
+        + "-2.2118325e-07 -2.8641868e-07  1.7980986e-07  2.6088992e-10  1.7675147e-10\n"
+        + "-3.0413460e-07 -4.9894969e-07  3.5403109e-07  1.8692631e-10  1.0088625e-10  6.2244443e-10\n"
+        + "\n"
+        + "EPOCH = 1996-12-29T21:00:00\n"
+        + "COV_REF_FRAME = EME2000\n"
+        + "3.4424505e-04\n"
+        + "4.5078162e-04  6.8935327e-04\n"
+        + "-3.0600067e-04 -4.1101230e-04  3.3420420e-04\n"
+        + "-3.2382549e-07 -4.5750731e-07  2.3738384e-07  4.3071339e-10\n"
+        + "-2.1007214e-07 -2.7530757e-07  1.6870875e-07  2.5077881e-10  1.8786258e-10\n"
+        + "-3.0302350e-07 -4.8783858e-07  3.4302008e-07  1.7581520e-10  1.0077514e-10  6.2244443e-10\n"
+        + "COVARIANCE_STOP";
+  }
+
+  public static OrbitEphemerisMessage buildOemWithCovariance() {
+    OrbitEphemerisMessage result = new OrbitEphemerisMessage();
+    result.setCcsds_oem_vers("2.0");
+    result.setHeader(new OdmCommonHeader().setCreation_date("1996-11-04T17:22:31").setOriginator("NASA/JPL"));
+
+    OemMetadata metadata = new OemMetadata();
+    metadata.setObject_name("MARS GLOBAL SURVEYOR");
+    metadata.setObject_id("1996-062A");
+    metadata.setCenter_name(CenterName.SUN); // MARS BARYCENTER
+    metadata.setRef_frame(ReferenceFrame.EME2000);
+    metadata.setTime_system(TimeSystem.UTC);
+    metadata.setStart_time("1996-12-28T21:29:07.267");
+    metadata.setUsable_start_time("1996-12-28T22:08:02.5");
+    metadata.setUsable_stop_time("1996-12-30T01:18:02.5");
+    metadata.setStop_time("1996-12-30T01:28:02.267");
+    metadata.setInterpolation("HERMITE");
+    metadata.setInterpolation_degree(7);
+
+    OemDataBlock block = new OemDataBlock();
+    block.setMetadata(metadata);
+    block.addComment("This block begins after trajectory correction maneuver TCM-3.");
+
+    block.addLine("1996-12-28T21:29:07.267", -2432.166, -063.042, 1742.754, 7.33702, -3.495867, -1.041945);
+    block.addLine("1996-12-28T21:59:02.267", -2445.234, -878.141, 1873.073, 1.86043, -3.421256, -0.996366);
+    block.addLine("1996-12-28T22:00:02.267", -2458.079, -683.858, 2007.684, 6.36786, -3.339563, -0.946654);
+    // intervening data records omitted here
+    block.addLine("1996-12-30T01:28:02.267", 2164.375, 1115.811, -688.131, -3.53328, -2.88452, 0.88535);
+
+    CovarianceMatrix cov = new CovarianceMatrix();
+    cov.setEpoch("1996-12-28T21:29:07.267");
+    cov.setCov_ref_frame(ReferenceFrame.EME2000);
+    cov.setCx_x(3.3313494e-04);
+    cov.setCy_x(4.6189273e-04).setCy_y(6.7824216e-04);
+    cov.setCz_x(-3.0700078e-04).setCz_y(-4.2212341e-04).setCz_z(3.2319319e-04);
+    cov.setCx_dot_x(-3.3493650e-07).setCx_dot_y(-4.6860842e-07).setCx_dot_z(2.4849495e-07)
+        .setCx_dot_x_dot(4.2960228e-10);
+    cov.setCy_dot_x(-2.2118325e-07).setCy_dot_y(-2.8641868e-07).setCy_dot_z(1.7980986e-07)
+        .setCy_dot_x_dot(2.6088992e-10).setCy_dot_y_dot(1.7675147e-10);
+    cov.setCz_dot_x(-3.0413460e-07).setCz_dot_y(-4.9894969e-07).setCz_dot_z(3.5403109e-07)
+        .setCz_dot_x_dot(1.8692631e-10).setCz_dot_y_dot(1.0088625e-10).setCz_dot_z_dot(6.2244443e-10);
+    block.addCovariance(cov);
+
+    cov = new CovarianceMatrix();
+    cov.setEpoch("1996-12-29T21:00:00");
+    cov.setCov_ref_frame(ReferenceFrame.EME2000);
+    cov.setCx_x(3.4424505e-04);
+    cov.setCy_x(4.5078162e-04).setCy_y(6.8935327e-04);
+    cov.setCz_x(-3.0600067e-04).setCz_y(-4.1101230e-04).setCz_z(3.3420420e-04);
+    cov.setCx_dot_x(-3.2382549e-07).setCx_dot_y(-4.5750731e-07).setCx_dot_z(2.3738384e-07)
+        .setCx_dot_x_dot(4.3071339e-10);
+    cov.setCy_dot_x(-2.1007214e-07).setCy_dot_y(-2.7530757e-07).setCy_dot_z(1.6870875e-07)
+        .setCy_dot_x_dot(2.5077881e-10).setCy_dot_y_dot(1.8786258e-10);
+    cov.setCz_dot_x(-3.0302350e-07).setCz_dot_y(-4.8783858e-07).setCz_dot_z(3.4302008e-07)
+        .setCz_dot_x_dot(1.7581520e-10).setCz_dot_y_dot(1.0077514e-10).setCz_dot_z_dot(6.2244443e-10);
+    block.addCovariance(cov);
+
+    result.addBlock(block);
     return result;
   }
 }

--- a/src/main/java/org/b612foundation/adam/opm/OemDataBlock.java
+++ b/src/main/java/org/b612foundation/adam/opm/OemDataBlock.java
@@ -1,0 +1,79 @@
+package org.b612foundation.adam.opm;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * One OrbitEphemerisMessage can contain multiple ephemerides blocks, each with its own metadata block and optional
+ * covariances.
+ */
+public class OemDataBlock {
+  /** Optional comments. */
+  private List<String> comments = new ArrayList<>();
+  /** Metadata, required */
+  private OemMetadata metadata = null;
+  /** Data, required: date, x, y, x, vx, vy, vz. Accelerations are optional, ignore them for now. */
+  private List<OemDataLine> ephemeris = new ArrayList<>();
+  /** Optional covariances, each with its own epoch. */
+  private List<CovarianceMatrix> covariances = new ArrayList<>();
+
+  public List<String> getComments() {
+    return comments;
+  }
+
+  public OemDataBlock setComments(List<String> comments) {
+    this.comments = comments;
+    return this;
+  }
+
+  public OemDataBlock addComment(String comment) {
+    this.comments.add(comment);
+    return this;
+  }
+
+  public OemMetadata getMetadata() {
+    return metadata;
+  }
+
+  public OemDataBlock setMetadata(OemMetadata metadata) {
+    this.metadata = metadata;
+    return this;
+  }
+
+  public List<OemDataLine> getLines() {
+    return ephemeris;
+  }
+
+  public OemDataBlock addLine(String date, double x, double y, double z, double vx, double vy, double vz) {
+    ephemeris.add(new OemDataLine(date, x, y, z, vx, vy, vz));
+    return this;
+  }
+
+  public List<CovarianceMatrix> getCovariances() {
+    return covariances;
+  }
+
+  public OemDataBlock addCovariance(CovarianceMatrix covariance) {
+    this.covariances.add(covariance);
+    return this;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(comments, metadata, ephemeris, covariances);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    OemDataBlock other = (OemDataBlock) obj;
+    return Objects.equals(comments, other.comments) && Objects.equals(metadata, other.metadata)
+        && Objects.equals(ephemeris, other.ephemeris) && Objects.equals(covariances, other.covariances);
+  }
+}

--- a/src/main/java/org/b612foundation/adam/opm/OemDataLine.java
+++ b/src/main/java/org/b612foundation/adam/opm/OemDataLine.java
@@ -1,0 +1,51 @@
+package org.b612foundation.adam.opm;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+/** Data line of OrbitEphemerisMessage: date, x, y, x, vx, vy, vz. Accelerations are optional, ignore them for now. */
+public class OemDataLine {
+  private String date;
+  private double[] point = new double[6];
+
+  public OemDataLine(String date, double x, double y, double z, double vx, double vy, double vz) {
+    this.date = date;
+    this.point[0] = x;
+    this.point[1] = y;
+    this.point[2] = z;
+    this.point[3] = vx;
+    this.point[4] = vy;
+    this.point[5] = vz;
+  }
+
+  public String getDate() {
+    return date;
+  }
+
+  public double[] getPoint() {
+    return point;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(date, point);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    OemDataLine other = (OemDataLine) obj;
+    return Objects.equals(date, other.date) && Arrays.equals(point, other.point);
+  }
+
+  @Override
+  public String toString() {
+    return date + " " + this.point[0] + " " + this.point[1] + " " + this.point[2] + " " + this.point[3] + " "
+        + this.point[4] + " " + this.point[5] + "\n";
+  }
+}

--- a/src/main/java/org/b612foundation/adam/opm/OemMetadata.java
+++ b/src/main/java/org/b612foundation/adam/opm/OemMetadata.java
@@ -1,0 +1,93 @@
+package org.b612foundation.adam.opm;
+
+import java.util.Objects;
+
+/** OEM metadata blocks add a few fields to the common metadata. */
+public class OemMetadata extends OdmCommonMetadata {
+  /** Start time of the ephemeris. Required. */
+  private String startTime = null;
+  /** Stop time of the ephemeris. Requires. */
+  private String stopTime = null;
+  /** Usable start time. Optional. */
+  private String usableStartTime = null;
+  /** Usable stop time. Optional. */
+  private String usableStopTime = null;
+  /** Interpolation method: Hermite, Linear, Lagrange. Optional. */
+  private String interpolation = null;
+  /** Interpolation degree, optional. */
+  private int interpolationDegree = 0;
+
+  public String getStart_time() {
+    return startTime;
+  }
+
+  public void setStart_time(String startTime) {
+    this.startTime = startTime;
+  }
+
+  public String getStop_time() {
+    return stopTime;
+  }
+
+  public void setStop_time(String stopTime) {
+    this.stopTime = stopTime;
+  }
+
+  public String getUsable_start_time() {
+    return usableStartTime;
+  }
+
+  public void setUsable_start_time(String usableStartTime) {
+    this.usableStartTime = usableStartTime;
+  }
+
+  public String getUsable_stop_time() {
+    return usableStopTime;
+  }
+
+  public void setUsable_stop_time(String usableStopTime) {
+    this.usableStopTime = usableStopTime;
+  }
+
+  public String getInterpolation() {
+    return interpolation;
+  }
+
+  public void setInterpolation(String interpolation) {
+    this.interpolation = interpolation;
+  }
+
+  public int getInterpolation_degree() {
+    return interpolationDegree;
+  }
+
+  public void setInterpolation_degree(int interpolationDegree) {
+    this.interpolationDegree = interpolationDegree;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), startTime, stopTime, usableStartTime, usableStopTime, interpolation,
+        interpolationDegree);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    OemMetadata other = (OemMetadata) obj;
+    // @formatter:off
+    return super.equals(other) 
+        && Objects.equals(startTime, other.startTime)
+        && Objects.equals(stopTime, other.stopTime)
+        && Objects.equals(usableStartTime, other.usableStartTime)
+        && Objects.equals(usableStopTime, other.usableStopTime)
+        && Objects.equals(interpolation, other.interpolation)
+        && Objects.equals(interpolationDegree, other.interpolationDegree);
+    // @formatter:on
+  }
+}

--- a/src/main/java/org/b612foundation/adam/opm/OrbitEphemerisMessage.java
+++ b/src/main/java/org/b612foundation/adam/opm/OrbitEphemerisMessage.java
@@ -1,0 +1,59 @@
+package org.b612foundation.adam.opm;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Orbit Parameter Message, or OPM, one of the three high-level message types defined in CCSDS ODM standard.
+ * https://public.ccsds.org/Pubs/502x0b2c1.pdf
+ */
+public class OrbitEphemerisMessage implements Serializable {
+  /** OEM version is required by standard. Should be the same value always. */
+  private String ccsdsOemVers = "2.0";
+  /** Headers are common for all message types. */
+  private OdmCommonHeader header;
+  /** One OEM message can contain several ephemerides, each with its own metadata block and optional covariance. */
+  private List<OemDataBlock> data = new ArrayList<>();
+
+  public String getCcsds_oem_vers() {
+    return ccsdsOemVers;
+  }
+
+  public OrbitEphemerisMessage setCcsds_oem_vers(String ccsdsOemVers) {
+    this.ccsdsOemVers = ccsdsOemVers;
+    return this;
+  }
+
+  public OdmCommonHeader getHeader() {
+    return header;
+  }
+
+  public OrbitEphemerisMessage setHeader(OdmCommonHeader header) {
+    this.header = header;
+    return this;
+  }
+
+  public void addBlock(OemDataBlock block) {
+    this.data.add(block);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(ccsdsOemVers, header, data);
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    OrbitEphemerisMessage other = (OrbitEphemerisMessage) obj;
+    return Objects.equals(ccsdsOemVers, other.ccsdsOemVers) && Objects.equals(header, other.header)
+        && Objects.equals(data, other.data);
+  }
+}

--- a/src/test/java/org/b612foundation/adam/opm/OdmFormatterTest.java
+++ b/src/test/java/org/b612foundation/adam/opm/OdmFormatterTest.java
@@ -58,4 +58,18 @@ public class OdmFormatterTest {
     OrbitParameterMessage parsed = OdmFormatter.parseOpmString(OdmScenarioBuilder.getOpmWithCovariance(type));
     Assert.assertEquals(parsed, expected);
   }
+
+  @Test
+  public void testBasicOemHappy() throws Exception {
+    OrbitEphemerisMessage expected = OdmScenarioBuilder.buildOemWithAccelerations();
+    OrbitEphemerisMessage parsed = OdmFormatter.parseOemString(OdmScenarioBuilder.getOemWithAccelerations());
+    Assert.assertEquals(parsed, expected);
+  }
+
+  @Test
+  public void testOemWithCovariance() throws Exception {
+    OrbitEphemerisMessage expected = OdmScenarioBuilder.buildOemWithCovariance();
+    OrbitEphemerisMessage parsed = OdmFormatter.parseOemString(OdmScenarioBuilder.getOemWithCovariance());
+    Assert.assertEquals(parsed, expected);
+  }
 }


### PR DESCRIPTION
The plan is to bold this to server as a common output format for various propagators. The standard is here: https://public.ccsds.org/Pubs/502x0b2c1.pdf

We already use OPM, which is part of the same standard, for input. The standard is plain text, but we also allow JSON version of the same data, which is easier to deal with in Python. This PR includes a parser for the plain text version, just in case, but we will likely use JSON for OEM as well. The weird mixed-case setter and getter names are to make the JSON serializer we use happy.