### PR TITLE
Make certain classes implement Serializable

### DIFF
--- a/src/main/java/org/b612foundation/adam/datamodel/PropagationParameters.java
+++ b/src/main/java/org/b612foundation/adam/datamodel/PropagationParameters.java
@@ -1,13 +1,13 @@
 package org.b612foundation.adam.datamodel;
 
+import java.io.Serializable;
 import org.b612foundation.adam.opm.OdmFormatter;
 import org.b612foundation.adam.opm.OdmParseException;
 import org.b612foundation.adam.opm.OrbitParameterMessage;
 
 import java.util.Objects;
 
-public class PropagationParameters {
-
+public class PropagationParameters implements Serializable {
   /**
    * Beginning of the ephemerides. Should be UTC. Generated ephemerides will start at this time.
    */

--- a/src/main/java/org/b612foundation/adam/opm/OemDataBlock.java
+++ b/src/main/java/org/b612foundation/adam/opm/OemDataBlock.java
@@ -1,5 +1,6 @@
 package org.b612foundation.adam.opm;
 
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -8,7 +9,7 @@ import java.util.Objects;
  * One OrbitEphemerisMessage can contain multiple ephemerides blocks, each with its own metadata block and optional
  * covariances.
  */
-public class OemDataBlock {
+public class OemDataBlock implements Serializable {
   /**
    * Optional comments.
    */

--- a/src/main/java/org/b612foundation/adam/opm/OemDataLine.java
+++ b/src/main/java/org/b612foundation/adam/opm/OemDataLine.java
@@ -1,12 +1,13 @@
 package org.b612foundation.adam.opm;
 
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.Objects;
 
 /**
  * Data line of OrbitEphemerisMessage: date, x, y, x, vx, vy, vz. Accelerations are optional, ignore them for now.
  */
-public class OemDataLine {
+public class OemDataLine implements Serializable {
   private String date;
   private double[] point = new double[6];
 


### PR DESCRIPTION
These classes will be used in the Apache Beam pipelines, so they need to be serializable in order for Beam to move data between workers.