### PR TITLE
Don't autoset the AdamObject id in constructor

### DIFF
--- a/src/main/java/org/b612foundation/adam/datamodel/AdamObject.java
+++ b/src/main/java/org/b612foundation/adam/datamodel/AdamObject.java
@@ -1,12 +1,13 @@
 package org.b612foundation.adam.datamodel;
 
 import java.util.Objects;
-import java.util.UUID;
 
 public abstract class AdamObject {
 
   /** Id for an object, unique among all AdamObjects. */
   private String uuid;
+
+  public AdamObject() {}
 
   public String getUuid() {
     return uuid;
@@ -15,10 +16,6 @@ public abstract class AdamObject {
   public AdamObject setUuid(String uuid) {
     this.uuid = uuid;
     return this;
-  }
-
-  public AdamObject() {
-    this.uuid = UUID.randomUUID().toString();
   }
 
   @Override


### PR DESCRIPTION
With the id auto-set, API requests come in with the uuid already set and fails validation. 
The APIs that use the AdamObject (and its subclasses) already explicitly set the ID before creating the object in the database.