### PR TITLE
Default enableLogCloseApproaches to true

### DIFF
--- a/src/main/java/org/b612foundation/adam/datamodel/PropagationParameters.java
+++ b/src/main/java/org/b612foundation/adam/datamodel/PropagationParameters.java
@@ -32,8 +32,8 @@ public class PropagationParameters implements Serializable {
   private OrbitParameterMessage opm;
   /** Whether to stop propagation on impact. */
   private boolean stopOnImpact;
-  /** Whether to record close approaches. */
-  private boolean enableLogCloseApproaches;
+  /** Whether to record close approaches. Defaults to true. */
+  private boolean enableLogCloseApproaches = true;
   /** Whether to stop on closest approach. Assumes logging of close approaches is set to true. */
   private boolean stopOnCloseApproach;
   /** The distance (meters) from the target body to stop on impact. */


### PR DESCRIPTION
I added the enableLogCloseApproaches in PropagationParameters in #53, but without defaulting the property to true, the web UI and Jupyter notebooks would need to be updated to configure the property. Trying to avoid disruptive updates, so default enableLogCloseApproaches to true, which is the behavior of the system prior to #53.