### PR TITLE
Some cleanup and version upgrades

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -12,20 +12,5 @@ jobs:
         with:
           java-version: 1.8
       - name: Build astrodynamics
-        run: mvn clean compile
-
-  test:
-    runs-on: ubuntu-latest
-    needs: build
-    steps:
-      - name: Test
-        run: mvn test
-
-  coverage:
-    runs-on: ubuntu-latest
-    needs: test
-    steps:
-      - name: Coverage report
         run: |
-          bash <(curl -s https://codecov.io/bash)
-          
+          mvn clean install && bash <(curl -s https://codecov.io/bash)

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -5,30 +5,27 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
-      with:
-        java-version: 1.8
-    - name: Build astrodynamics
-      run: mvn clean compile
+      - uses: actions/checkout@v2
+      - name: Set up JDK 1.8
+        uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Build astrodynamics
+        run: mvn clean compile
 
   test:
     runs-on: ubuntu-latest
-
+    needs: build
     steps:
       - name: Test
-        needs: build
         run: mvn test
 
   coverage:
     runs-on: ubuntu-latest
-
+    needs: test
     steps:
       - name: Coverage report
-        needs: test
         run: |
           bash <(curl -s https://codecov.io/bash)
-
+          

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -13,6 +13,19 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 1.8
-    - name: Build and test astrodynamics
-      run: |
-        mvn compile test
+    - name: Build astrodynamics
+      run: mvn clean compile
+
+  test:
+    steps:
+      - name: Test
+        needs: build
+        run: mvn test
+
+  coverage:
+    steps:
+      - name: Coverage report
+        needs: test
+        run: |
+          bash <(curl -s https://codecov.io/bash)
+

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -4,7 +4,6 @@ on: [push]
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
@@ -17,12 +16,16 @@ jobs:
       run: mvn clean compile
 
   test:
+    runs-on: ubuntu-latest
+
     steps:
       - name: Test
         needs: build
         run: mvn test
 
   coverage:
+    runs-on: ubuntu-latest
+
     steps:
       - name: Coverage report
         needs: test

--- a/.gitignore
+++ b/.gitignore
@@ -19,12 +19,12 @@ target/
 *.tar.gz
 *.rar
 
-#Eclipse Settings Files
+# Eclipse Settings Files
 .settings
 .classpath
 .project
 
-#IntelliJ Project file
+# IntelliJ Project file
 .idea
 *.iml
 
@@ -32,3 +32,6 @@ target/
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
 /bin/
+
+# jenv version
+.java-version

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
   <modelVersion>4.0.0</modelVersion>
@@ -58,6 +59,25 @@
             <goals>
               <goal>display-dependency-updates</goal>
               <goal>display-plugin-updates</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.8.5</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>prepare-agent</goal>
+            </goals>
+          </execution>
+          <execution>
+            <id>report</id>
+            <phase>test</phase>
+            <goals>
+              <goal>report</goal>
             </goals>
           </execution>
         </executions>

--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.8</version>
+      <version>1.18.12</version>
       <scope>provided</scope>
     </dependency>
     <dependency>
@@ -35,14 +35,14 @@
       <version>2.11.0</version>
     </dependency>
     <dependency>
-      <groupId>com.google.googlejavaformat</groupId>
-      <artifactId>google-java-format</artifactId>
-      <version>1.7</version>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <version>29.0-jre</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>4.13</version>
       <scope>test</scope>
     </dependency>
   </dependencies>
@@ -52,7 +52,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
-        <version>2.1</version>
+        <version>2.7</version>
         <executions>
           <execution>
             <phase>compile</phase>
@@ -63,6 +63,7 @@
           </execution>
         </executions>
       </plugin>
+      <!-- Java Code Coverage report, used in CI/CD -->
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>

--- a/src/test/java/org/b612foundation/adam/datamodel/estimation/OdDataExamplesTest.java
+++ b/src/test/java/org/b612foundation/adam/datamodel/estimation/OdDataExamplesTest.java
@@ -15,6 +15,7 @@ public class OdDataExamplesTest {
   @Test
   public void configuringInputDataExample() throws JsonProcessingException {
     // Example of turning a raw DES OBS file into a base64 encoded one that could be passed safely to a REST service
+    // @formatter:off
     var desRawObsFileText =
         "433     54617.0000000000 O  78.2887200000  26.5336200000  13.5600000000 X  568   0.0010000000   0.0000000000  -1.0000000000 -0.1000000E+01 X\n" +
             "433     54624.0000000000 O  85.2759500000  26.3621300000  13.5200000000 X  568   0.0010000000   0.0000000000  -1.0000000000 -0.1000000E+01 X\n" +
@@ -25,6 +26,7 @@ public class OdDataExamplesTest {
             "433     54659.0000000000 O 119.7126800000  20.6130900000  13.4000000000 X  568   0.0010000000   0.0010000000  -1.0000000000 -0.1000000E+01 X\n" +
             "433     54666.0000000000 O 126.2366900000  18.6056500000  13.4000000000 X  568   0.0010000000   0.0010000000  -1.0000000000 -0.1000000E+01 X\n" +
             "433     54673.0000000000 O 132.5936500000  16.3820000000  13.4100000000 X  568   0.0010000000   0.0010000000  -1.0000000000 -0.1000000E+01 X";
+    // @formatter:on
     var base64ObsFile = Base64.getEncoder().encodeToString(desRawObsFileText.getBytes());
     // String desObsFileFromBase64 = new String(Base64.getDecoder().decode(base64ObsFile));
 
@@ -130,6 +132,8 @@ public class OdDataExamplesTest {
 
     ObjectMapper om = new ObjectMapper();
     om.configure(SerializationFeature.INDENT_OUTPUT, true);
+
+    // TODO: make assertions to ensure correct behavior of whatever is being tested
     System.out.println("IOD Configuration");
     System.out.println(om.writeValueAsString(thorIodConfig));
     System.out.println("IOD Run Parameters");

--- a/src/test/java/org/b612foundation/adam/datamodel/estimation/OorbConfigWriterTest.java
+++ b/src/test/java/org/b612foundation/adam/datamodel/estimation/OorbConfigWriterTest.java
@@ -20,6 +20,7 @@ public class OorbConfigWriterTest {
     OorbConfigWriter.writeConfiguration(tmpConfig, config, PropagationConfigurationFactory.getAllMajorBodiesConfig());
     var lines = Files.readAllLines(tmpConfig);
     lines.forEach(System.out::println);
+    // TODO: make assertions that the written oorb config is correct; prefer assertion over printlns
   }
 
   @Test


### PR DESCRIPTION
- Remove google-java-format, since we aren't currently generating java needs to be formatted. (We should, however, eventually execute the google-java-format jar file against the codebase.)
- Up the `versions-maven-plugin` version to 2.5, which is not the latest version, but at least Mac homebrew maven (v 3.6.3) doesn't complain about incompatible versions. I *think* `versions-maven-plugin` version 2.7 works when building the astrodynamics code on Mac with maven 3.6.3, but to be safe, using 2.5.
- Put some TODOs in the tests to make the tests assert correct behavior
