### PR TITLE
OpmHelper.getCartesianStateVector Feature

### DIFF
--- a/src/main/java/org/b612foundation/adam/opm/OpmHelper.java
+++ b/src/main/java/org/b612foundation/adam/opm/OpmHelper.java
@@ -22,7 +22,7 @@ public class OpmHelper {
     if (opm.getKeplerian() != null) {
       // ODM uses km for semimajor axis and km^3/s^2 for gravitational constant. Orekit uses m and
       // m^3/s^2.
-      // Because not doing any state or frame transformation but epoch and frame are irrelevant
+      // Because not doing any state or frame transformation but epoch and frame
       // are paramaters setting them to stand-in values
       final Frame standInFrame = FramesFactory.getICRF();
       final AbsoluteDate standInEpoch = AbsoluteDate.ARBITRARY_EPOCH;

--- a/src/main/java/org/b612foundation/adam/opm/OpmHelper.java
+++ b/src/main/java/org/b612foundation/adam/opm/OpmHelper.java
@@ -1,0 +1,64 @@
+package org.b612foundation.adam.opm;
+
+import org.hipparchus.geometry.euclidean.threed.Vector3D;
+import org.orekit.frames.Frame;
+import org.orekit.frames.FramesFactory;
+import org.orekit.orbits.KeplerianOrbit;
+import org.orekit.orbits.PositionAngle;
+import org.orekit.time.AbsoluteDate;
+
+import static org.b612foundation.adam.astro.AstroConstants.KM_TO_M;
+
+public class OpmHelper {
+
+  /**
+   * Given an OPM message it will extract a cartesian position/velocity StateVector by converting
+   * the Keplerian state, if it is supplied, or by returning the Cartesian vectors directly
+   *
+   * @param opm
+   * @return StateVector
+   */
+  public static StateVector getCartesianStateVector(OrbitParameterMessage opm) {
+    if (opm.getKeplerian() != null) {
+      // ODM uses km for semimajor axis and km^3/s^2 for gravitational constant. Orekit uses m and
+      // m^3/s^2.
+      // Because not doing any state or frame transformation but epoch and frame are irrelevant
+      // are paramaters setting them to stand-in values
+      final Frame standInFrame = FramesFactory.getICRF();
+      final AbsoluteDate standInEpoch = AbsoluteDate.ARBITRARY_EPOCH;
+      final double epsilon = 1e-20;
+      final double gm = opm.getKeplerian().getGm() * (KM_TO_M * KM_TO_M * KM_TO_M);
+      final double sma = opm.getKeplerian().getSemi_major_axis() * KM_TO_M;
+      final double ecc = opm.getKeplerian().getEccentricity();
+      final double inc = Math.toRadians(opm.getKeplerian().getInclination());
+      final double argPeri = Math.toRadians(opm.getKeplerian().getArg_of_pericenter());
+      final double raan = Math.toRadians(opm.getKeplerian().getRa_of_asc_node());
+      final PositionAngle anomalyType;
+      final double anomaly;
+      if (Math.abs(opm.getKeplerian().getMean_anomaly()) > epsilon) {
+        anomalyType = PositionAngle.MEAN;
+        anomaly = Math.toRadians(opm.getKeplerian().getMean_anomaly());
+      } else {
+        anomalyType = PositionAngle.TRUE;
+        anomaly = Math.toRadians(opm.getKeplerian().getTrue_anomaly());
+      }
+
+      final KeplerianOrbit state =
+          new KeplerianOrbit(
+              sma, ecc, inc, argPeri, raan, anomaly, anomalyType, standInFrame, standInEpoch, gm);
+      final Vector3D position = state.getPVCoordinates().getPosition();
+      final Vector3D velocity = state.getPVCoordinates().getVelocity();
+
+      return new StateVector()
+          .setEpoch(opm.getState_vector().getEpoch())
+          .setX(position.getX() / KM_TO_M)
+          .setY(position.getY() / KM_TO_M)
+          .setZ(position.getZ() / KM_TO_M)
+          .setX_dot(velocity.getX() / KM_TO_M)
+          .setY_dot(velocity.getY() / KM_TO_M)
+          .setZ_dot(velocity.getZ() / KM_TO_M);
+    } else {
+      return opm.getState_vector();
+    }
+  }
+}

--- a/src/test/java/org/b612foundation/adam/opm/OpmHelperTest.java
+++ b/src/test/java/org/b612foundation/adam/opm/OpmHelperTest.java
@@ -1,0 +1,132 @@
+package org.b612foundation.adam.opm;
+
+import org.b612foundation.adam.util.OrekitDataLoader;
+import org.junit.Before;
+import org.junit.Test;
+import org.orekit.frames.FramesFactory;
+import org.orekit.orbits.KeplerianOrbit;
+import org.orekit.orbits.PositionAngle;
+import org.orekit.time.AbsoluteDate;
+import org.orekit.time.TimeScalesFactory;
+import org.orekit.utils.Constants;
+
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+
+import static org.b612foundation.adam.astro.AstroConstants.KM_TO_M;
+import static org.junit.Assert.assertEquals;
+
+public class OpmHelperTest {
+
+  @Before
+  public void before() {
+    OrekitDataLoader.initialize();
+  }
+
+  @Test
+  public void testFromKeplerianTrueAnomalyOpm() {
+    final double posTolerance = 1e-12;
+    final double velTolerance = 1e-12;
+    final double sma = 10000 * KM_TO_M;
+    final double ecc = 0.003;
+    final double inc = Math.toRadians(40);
+    final double raan = Math.toRadians(50);
+    final double pa = Math.toRadians(60);
+    final double ta = Math.toRadians(70);
+    final double mu = Constants.WGS84_EARTH_MU;
+    final AbsoluteDate epoch = new AbsoluteDate(2020, 1, 2, 3, 4, 5.0, TimeScalesFactory.getTT());
+    KeplerianOrbit keplerianOrbit =
+        new KeplerianOrbit(
+            sma, ecc, inc, raan, pa, ta, PositionAngle.TRUE, FramesFactory.getICRF(), epoch, mu);
+    StateVector expected = cartesianStateFromKeplerian(keplerianOrbit);
+    OrbitParameterMessage opm = opmFromKeplerian(keplerianOrbit, PositionAngle.TRUE);
+    StateVector actual = OpmHelper.getCartesianStateVector(opm);
+    compareState(expected, actual, posTolerance, velTolerance);
+  }
+
+  @Test
+  public void testFromKeplerianMeanAnomalyOpm() {
+    final double posTolerance = 1e-12;
+    final double velTolerance = 1e-12;
+    final double sma = 10000 * KM_TO_M;
+    final double ecc = 0.003;
+    final double inc = Math.toRadians(40);
+    final double raan = Math.toRadians(50);
+    final double pa = Math.toRadians(60);
+    final double ma = Math.toRadians(70);
+    final double mu = Constants.WGS84_EARTH_MU;
+    final AbsoluteDate epoch = new AbsoluteDate(2020, 1, 2, 3, 4, 5.0, TimeScalesFactory.getTT());
+    KeplerianOrbit keplerianOrbit =
+        new KeplerianOrbit(
+            sma, ecc, inc, raan, pa, ma, PositionAngle.MEAN, FramesFactory.getICRF(), epoch, mu);
+    StateVector expected = cartesianStateFromKeplerian(keplerianOrbit);
+    OrbitParameterMessage opm = opmFromKeplerian(keplerianOrbit, PositionAngle.MEAN);
+    StateVector actual = OpmHelper.getCartesianStateVector(opm);
+    compareState(expected, actual, posTolerance, velTolerance);
+  }
+
+  @Test
+  public void testFromCartesianOpm() {
+    final double posTolerance = 1e-12;
+    final double velTolerance = 1e-12;
+    String epochString = "2000-01-02T23:59:37.816Z";
+    ZonedDateTime startDate = ZonedDateTime.parse(epochString);
+
+    StateVector state =
+        new StateVector()
+            .setEpoch(startDate.format(DateTimeFormatter.ISO_ZONED_DATE_TIME))
+            .setX(10000)
+            .setY(20000)
+            .setZ(30000)
+            .setX_dot(100)
+            .setY_dot(200)
+            .setZ_dot(300);
+    OrbitParameterMessage opm = new OrbitParameterMessage().setState_vector(state);
+
+    StateVector extractState = OpmHelper.getCartesianStateVector(opm);
+    compareState(state, extractState, posTolerance, velTolerance);
+  }
+
+  private void compareState(
+      StateVector expected, StateVector actual, double posTolerance, double velTolerance) {
+    assertEquals(expected.getEpoch(), actual.getEpoch());
+    assertEquals(expected.getX(), actual.getX(), posTolerance);
+    assertEquals(expected.getY(), actual.getY(), posTolerance);
+    assertEquals(expected.getZ(), actual.getZ(), posTolerance);
+    assertEquals(expected.getX_dot(), actual.getX_dot(), velTolerance);
+    assertEquals(expected.getY_dot(), actual.getY_dot(), velTolerance);
+    assertEquals(expected.getZ_dot(), actual.getZ_dot(), velTolerance);
+  }
+
+  private StateVector cartesianStateFromKeplerian(KeplerianOrbit orbit) {
+    return new StateVector()
+        .setEpoch(orbit.getDate().toString(0))
+        .setX(orbit.getPVCoordinates().getPosition().getX() / KM_TO_M)
+        .setY(orbit.getPVCoordinates().getPosition().getY() / KM_TO_M)
+        .setZ(orbit.getPVCoordinates().getPosition().getZ() / KM_TO_M)
+        .setX_dot(orbit.getPVCoordinates().getVelocity().getX() / KM_TO_M)
+        .setY_dot(orbit.getPVCoordinates().getVelocity().getY() / KM_TO_M)
+        .setZ_dot(orbit.getPVCoordinates().getVelocity().getZ() / KM_TO_M);
+  }
+
+  private OrbitParameterMessage opmFromKeplerian(KeplerianOrbit orbit, PositionAngle angleType) {
+    KeplerianElements elements =
+        new KeplerianElements()
+            .setGm(orbit.getMu() / KM_TO_M / KM_TO_M / KM_TO_M)
+            .setArg_of_pericenter(Math.toDegrees(orbit.getPerigeeArgument()))
+            .setEccentricity(orbit.getE())
+            .setInclination(Math.toDegrees(orbit.getI()))
+            .setRa_of_asc_node(Math.toDegrees(orbit.getRightAscensionOfAscendingNode()))
+            .setSemi_major_axis(orbit.getA() / KM_TO_M);
+
+    if (angleType == PositionAngle.TRUE) {
+      elements = elements.setTrue_anomaly(Math.toDegrees(orbit.getTrueAnomaly()));
+    } else {
+      elements = elements.setMean_anomaly(Math.toDegrees(orbit.getMeanAnomaly()));
+    }
+
+    return new OrbitParameterMessage()
+        .setState_vector(new StateVector().setEpoch(orbit.getDate().toString(0)))
+        .setKeplerian(elements);
+  }
+}

--- a/src/test/java/org/b612foundation/adam/util/OrekitDataLoaderTest.java
+++ b/src/test/java/org/b612foundation/adam/util/OrekitDataLoaderTest.java
@@ -1,9 +1,11 @@
 package org.b612foundation.adam.util;
 
-import org.junit.*;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.orekit.data.DataContext;
-import org.orekit.errors.OrekitException;
 import org.orekit.time.AbsoluteDate;
 
 import java.io.IOException;
@@ -17,14 +19,7 @@ public class OrekitDataLoaderTest {
   @Rule public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
   @Before
-  public void setUp() {
-    // Clear the properties and environment variables in case it's set on the system
-    environmentVariables.set(OrekitDataLoader.OREKIT_DATA_ENVIRONMENT_VARIABLE_NAME, null);
-    System.clearProperty(OrekitDataLoader.OREKIT_DATA_RUNTIME_PROPERTY_NAME);
-  }
-
-  @After
-  public void tearDown() {
+  public void before() {
     environmentVariables.set(OrekitDataLoader.OREKIT_DATA_ENVIRONMENT_VARIABLE_NAME, null);
     System.clearProperty(OrekitDataLoader.OREKIT_DATA_RUNTIME_PROPERTY_NAME);
     OrekitDataLoader.IsLoaded.set(false);
@@ -55,11 +50,6 @@ public class OrekitDataLoaderTest {
     System.setProperty(
         OrekitDataLoader.OREKIT_DATA_RUNTIME_PROPERTY_NAME, UUID.randomUUID().toString());
     OrekitDataLoader.initialize();
-  }
-
-  @Test(expected = OrekitException.class)
-  public void testExpectUninitializedToThrowException() {
-    System.out.println(new AbsoluteDate());
   }
 
   @Test

--- a/src/test/java/org/b612foundation/adam/util/OrekitDataLoaderTest.java
+++ b/src/test/java/org/b612foundation/adam/util/OrekitDataLoaderTest.java
@@ -1,9 +1,6 @@
 package org.b612foundation.adam.util;
 
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.*;
 import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.orekit.data.DataContext;
 import org.orekit.time.AbsoluteDate;
@@ -19,7 +16,8 @@ public class OrekitDataLoaderTest {
   @Rule public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
   @Before
-  public void before() {
+  @After
+  public void cleanup() {
     environmentVariables.set(OrekitDataLoader.OREKIT_DATA_ENVIRONMENT_VARIABLE_NAME, null);
     System.clearProperty(OrekitDataLoader.OREKIT_DATA_RUNTIME_PROPERTY_NAME);
     OrekitDataLoader.IsLoaded.set(false);


### PR DESCRIPTION
Add `OpmHelper` class with `getCartesianStateVector` method to extract the StateVector or convert the Keplerian state into a state vector.

Side effect, had to remove the "test uninitialized" test from the OrekitDataLoader. If Orekit methods are run anywhere then the datatables area already loaded so the cleanup methods we used for faking it out for testing previously don't work any longer. 