### PR TITLE
Migrate OrbitPositionType to non-STK package

### DIFF
--- a/astrodynamics-core/src/main/java/org/b612foundation/adam/propagators/OrbitPositionType.java
+++ b/astrodynamics-core/src/main/java/org/b612foundation/adam/propagators/OrbitPositionType.java
@@ -1,4 +1,4 @@
-package org.b612foundation.adam.stk.propagators;
+package org.b612foundation.adam.propagators;
 
 /** The type of position of an object in orbit */
 public enum OrbitPositionType {

--- a/astrodynamics-stk/src/main/java/org/b612foundation/adam/stk/propagators/OrbitPointSummary.java
+++ b/astrodynamics-stk/src/main/java/org/b612foundation/adam/stk/propagators/OrbitPointSummary.java
@@ -9,6 +9,7 @@ import org.b612foundation.adam.common.DistanceType;
 import org.b612foundation.adam.common.DistanceUnits;
 import org.b612foundation.adam.opm.OdmCommonMetadata.ReferenceFrame;
 import org.b612foundation.adam.opm.OdmCommonMetadata.TimeSystem;
+import org.b612foundation.adam.propagators.OrbitPositionType;
 
 /** TODO: naming? */
 @Value

--- a/astrodynamics-stk/src/main/java/org/b612foundation/adam/stk/propagators/StkSegmentPropagatedOrbit.java
+++ b/astrodynamics-stk/src/main/java/org/b612foundation/adam/stk/propagators/StkSegmentPropagatedOrbit.java
@@ -35,6 +35,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.logging.Logger;
+import org.b612foundation.adam.propagators.OrbitPositionType;
 
 import static agi.foundation.stoppingconditions.StoppingConditionTriggeredBehavior.CONTINUE_TO_NEXT_EVENT;
 import static agi.foundation.stoppingconditions.StoppingConditionTriggeredBehavior.STOP_FUNCTION;

--- a/astrodynamics-stk/src/main/java/org/b612foundation/adam/stk/propagators/StkSegmentPropagator.java
+++ b/astrodynamics-stk/src/main/java/org/b612foundation/adam/stk/propagators/StkSegmentPropagator.java
@@ -10,6 +10,7 @@ import org.b612foundation.adam.datamodel.PropagatorConfiguration;
 import org.b612foundation.adam.exceptions.AdamPropagationException;
 import org.b612foundation.adam.opm.OrbitEphemerisMessage;
 import org.b612foundation.adam.opm.OrbitParameterMessage;
+import org.b612foundation.adam.propagators.OrbitPositionType;
 import org.b612foundation.adam.propagators.OrbitPropagator;
 import org.b612foundation.stk.StkLicense;
 

--- a/astrodynamics-stk/src/test/java/org/b612foundation/adam/stk/propagators/StkSegmentPropagatorTest.java
+++ b/astrodynamics-stk/src/test/java/org/b612foundation/adam/stk/propagators/StkSegmentPropagatorTest.java
@@ -15,6 +15,7 @@ import org.b612foundation.adam.opm.OdmCommonMetadata.TimeSystem;
 import org.b612foundation.adam.opm.OemDataLine;
 import org.b612foundation.adam.opm.OrbitEphemerisMessage;
 import org.b612foundation.adam.opm.StateVector;
+import org.b612foundation.adam.propagators.OrbitPositionType;
 import org.b612foundation.stk.StkLicense;
 import org.junit.Before;
 import org.junit.Test;


### PR DESCRIPTION
OrbitPositionType is used outside of astrodynamics, but doesn't require STK, so move it to core. This also helps remove the API's dependency on the STK module.