### PR TITLE
Change name of stopOnImpactDistanceMeters to stopOnImpactAltitudeMeters

### DIFF
--- a/astrodynamics-core/src/main/java/org/b612foundation/adam/datamodel/PropagationParameters.java
+++ b/astrodynamics-core/src/main/java/org/b612foundation/adam/datamodel/PropagationParameters.java
@@ -33,8 +33,8 @@ public class PropagationParameters implements Serializable {
   private boolean enableLogCloseApproaches = true;
   /** Whether to stop on closest approach. Assumes logging of close approaches is set to true. */
   private boolean stopOnCloseApproach;
-  /** The distance (meters) from the target body to stop on impact. */
-  private long stopOnImpactDistanceMeters;
+  /** The object's altitude (meters) from the target body's surface, at which to stop on impact. */
+  private long stopOnImpactAltitudeMeters;
   /**
    * The epoch (in UTC) after which to stop on close approach. Assumes logging of close approaches
    * is set to true.
@@ -66,7 +66,7 @@ public class PropagationParameters implements Serializable {
     copy.setStopOnImpact(stopOnImpact);
     copy.setEnableLogCloseApproaches(enableLogCloseApproaches);
     copy.setStopOnCloseApproach(stopOnCloseApproach);
-    copy.setStopOnImpactDistanceMeters(stopOnImpactDistanceMeters);
+    copy.setStopOnImpactAltitudeMeters(stopOnImpactAltitudeMeters);
     copy.setStopOnCloseApproachAfterEpoch(stopOnCloseApproachAfterEpoch);
     copy.setCloseApproachRadiusFromTargetMeters(closeApproachRadiusFromTargetMeters);
     copy.setPropagationType(propagationType);
@@ -162,12 +162,12 @@ public class PropagationParameters implements Serializable {
     return this;
   }
 
-  public long getStopOnImpactDistanceMeters() {
-    return this.stopOnImpactDistanceMeters;
+  public long getStopOnImpactAltitudeMeters() {
+    return this.stopOnImpactAltitudeMeters;
   }
 
-  public PropagationParameters setStopOnImpactDistanceMeters(long distance) {
-    this.stopOnImpactDistanceMeters = distance;
+  public PropagationParameters setStopOnImpactAltitudeMeters(long distance) {
+    this.stopOnImpactAltitudeMeters = distance;
     return this;
   }
 

--- a/astrodynamics-stk/src/main/java/org/b612foundation/adam/stk/propagators/StkSegmentPropagator.java
+++ b/astrodynamics-stk/src/main/java/org/b612foundation/adam/stk/propagators/StkSegmentPropagator.java
@@ -33,7 +33,6 @@ public final class StkSegmentPropagator implements OrbitPropagator {
   private JulianDate startDate;
   private JulianDate endDate;
   private Duration step;
-  private OrbitPointSummary finalState;
 
   public StkSegmentPropagator() {
     StkLicense.activate();
@@ -67,8 +66,6 @@ public final class StkSegmentPropagator implements OrbitPropagator {
       orbit = initializeOrbit(opm, config);
       orbit.propagate(propagationParams, epoch, endDate);
 
-      finalState = determineFinalState();
-
       // Adjust end date to when the propagation actually ended, e.g. when using stopping conditions
       if (orbit.getRawDates().size() > 0) {
         endDate = orbit.getRawDates().get(orbit.getRawDates().size() - 1);
@@ -101,33 +98,8 @@ public final class StkSegmentPropagator implements OrbitPropagator {
     return orbit.getCloseApproaches();
   }
 
-  private OrbitPointSummary determineFinalState() {
-    if (orbit.getImpact().isPresent()) {
-      return orbit.getImpact().get();
-    } else if (orbit.getStoppedOnCloseApproach()) {
-      List<OrbitPointSummary> closeApproaches = getCloseApproaches();
-      return closeApproaches.get(closeApproaches.size() - 1);
-    }
-
-    OrbitPointSummary finalPositionAndTime = orbit.getFinalPositionAndTime();
-    return OrbitPointSummary.builder()
-        .orbitPositionType(OrbitPositionType.MISS)
-        .stopped(finalPositionAndTime.isStopped())
-        .time(finalPositionAndTime.getTime())
-        .timeIsoFormat(finalPositionAndTime.getTimeIsoFormat())
-        .timeSystem(finalPositionAndTime.getTimeSystem())
-        .targetBody(finalPositionAndTime.getTargetBody())
-        .targetBodyCenteredPositionUnits(finalPositionAndTime.getTargetBodyCenteredPositionUnits())
-        .targetBodyCenteredPosition(finalPositionAndTime.getTargetBodyCenteredPosition())
-        .targetBodyReferenceFrame(finalPositionAndTime.getTargetBodyReferenceFrame())
-        .distanceFromTarget(finalPositionAndTime.getDistanceFromTarget())
-        .distanceUnits(finalPositionAndTime.getDistanceUnits())
-        .distanceType(finalPositionAndTime.getDistanceType())
-        .build();
-  }
-
   public OrbitPointSummary getFinalState() {
-    return finalState;
+    return orbit.getFinalPositionAndTime();
   }
 
   public ReferenceFrame getReferenceFrame() {

--- a/astrodynamics-stk/src/test/java/org/b612foundation/adam/stk/propagators/StkSegmentPropagatorTest.java
+++ b/astrodynamics-stk/src/test/java/org/b612foundation/adam/stk/propagators/StkSegmentPropagatorTest.java
@@ -193,7 +193,7 @@ public final class StkSegmentPropagatorTest {
             startDate, endDate, SECONDS_IN_DAY, ASTEROID_101_INITIAL_STATE_VECTOR);
     params.setStopOnImpact(true);
     params.setCloseApproachRadiusFromTargetMeters(7.0e9);
-    params.setStopOnImpactDistanceMeters(500_000); // 500km
+    params.setStopOnImpactAltitudeMeters(500_000); // 500km
     JulianDate expectedImpactDate = parseUtcAsJulian("2010-12-31T01:13:46.620000Z");
 
     StkSegmentPropagator propagator = new StkSegmentPropagator();
@@ -212,6 +212,8 @@ public final class StkSegmentPropagatorTest {
     assertThat(finalState.getDistanceFromTarget())
         .isWithin(1e3)
         .of(500000 + WorldGeodeticSystem1984.SemimajorAxis);
+    assertThat(finalState.getDistanceType()).isEqualTo(DistanceType.ALTITUDE);
+    assertThat(finalState.getDistanceUnits()).isEqualTo(DistanceUnits.METERS);
   }
 
   @Test


### PR DESCRIPTION
Update the propagator documentation and naming.

There was a method `determineFinalState()` in the `StkSegmentPropagator` class that checked for presence of impact, a stop on close approach, or just a miss, and returned the final state. I moved it to the `StkSegmentPropagatorOrbit` class to keep the code encapsulated.